### PR TITLE
Configure test coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Docs: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: ".github:"
+
+  # Maintain dependencies for Go
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "maven:"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         # -B (batch mode) to suppress progress (pollutes logs)
         # -DskipITs to skip integration tests (they are run in a separate job)
         # -Pcoverage to use a Maven profile, which generates a test coverage report
-        run: mvn -B -DskipITs -Pcoverage verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=fork-conduit-kafka-connect-wrapper
+        run: mvn -B -DskipITs -Pcoverage verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=conduit-kafka-connect-wrapper
 
   integration-tests:
     # Run separately, because they do not affect the code analysis,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         # Skipping the tests as they have already been run above
+        # -B (batch mode) to suppress progress (pollutes logs)
+        # -DskipITs to skip integration tests (they are run in a separate job)
+        # -Pcoverage to use a Maven profile, which generates a test coverage report
         run: mvn -B -DskipITs -Pcoverage verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=fork-conduit-kafka-connect-wrapper
 
   integration-tests:
@@ -70,6 +73,8 @@ jobs:
         run: docker compose -f src/test/resources/docker-compose.yml up -d --wait
 
       - name: Install test library to local Maven repo
+        # Not available in a public Maven repo, so we need to provide a pre-built artifact,
+        # and install to the local Maven repo.
         run: mvn install:install-file -Dfile=libs/jdbc-connector-for-apache-kafka-6.7.0-SNAPSHOT.jar -DgroupId=io.aiven -DartifactId=jdbc-connector-for-apache-kafka -Dversion=6.7.0-SNAPSHOT -Dpackaging=jar
 
       - name: Run intergration tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,6 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-      - name: Install test library to local Maven repo
-        run: mvn install:install-file -Dfile=libs/jdbc-connector-for-apache-kafka-6.7.0-SNAPSHOT.jar -DgroupId=io.aiven -DartifactId=jdbc-connector-for-apache-kafka -Dversion=6.7.0-SNAPSHOT -Dpackaging=jar
-
       - name: Test and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,47 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
 jobs:
-  tests:
-    name: Tests
+  # Unit tests and the Sonar analysis is done in a single job
+  # because SonarCloud requires the test coverage report,
+  # which is generated after unit tests are executed.
+  # It's possible to do it in separate jobs (so it appears a bit prettier in the PR checks),
+  # but that requires the jobs to share the report (which can be done, but doesn't pay out).
+  test-analyze:
+    name: Test and analyze code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'adopt'
+
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Install test library to local Maven repo
+        run: mvn install:install-file -Dfile=libs/jdbc-connector-for-apache-kafka-6.7.0-SNAPSHOT.jar -DgroupId=io.aiven -DartifactId=jdbc-connector-for-apache-kafka -Dversion=6.7.0-SNAPSHOT -Dpackaging=jar
+
+      - name: Test and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        # Skipping the tests as they have already been run above
+        run: mvn -B -DskipITs -Pcoverage verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=fork-conduit-kafka-connect-wrapper
+
+  integration-tests:
+    # Run separately, because they do not affect the code analysis,
+    # and because it will help get the unit tests and SonarCloud results sooner.
+    name: Integration tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,42 +72,5 @@ jobs:
       - name: Install test library to local Maven repo
         run: mvn install:install-file -Dfile=libs/jdbc-connector-for-apache-kafka-6.7.0-SNAPSHOT.jar -DgroupId=io.aiven -DartifactId=jdbc-connector-for-apache-kafka -Dversion=6.7.0-SNAPSHOT -Dpackaging=jar
 
-      - name: Run tests
+      - name: Run intergration tests
         run: mvn integration-test verify
-
-  sonarcloud-analysis:
-    name: Trigger SonarCloud analysis
-    needs: tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: 'adopt'
-
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
-      - name: Build and analyze
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        # Skipping the tests as they have already been run above
-        run: mvn -B -DskipTests verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=conduit-kafka-connect-wrapper

--- a/pom.xml
+++ b/pom.xml
@@ -254,4 +254,38 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.7</version>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <configuration>
+                                    <formats>
+                                        <format>XML</format>
+                                    </formats>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Currently, code coverage is not calculated. SonarCloud needs a test coverage report generated after unit tests are run.

This PR configures JaCoCo to generate the report, and then configures SonarCloud to use that report. 

In this PR, code coverage is not reported, since there's no base coverage on the main branch. Once this PR is merged, future PRs will have the coverage reported, and the check will pass if code coverage for new lines is >80%.

This PR also configures dependabot.

Here's how it looks like in a fork of this repo:

![Screenshot from 2022-05-13 15-08-22](https://user-images.githubusercontent.com/2166300/168291739-a518ae4d-2c77-40ad-9e62-280f70271845.png)
