### PR TITLE
OpenCDC changes, part 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <grpc.version>1.47.0</grpc.version>
+        <grpc.version>1.48.0</grpc.version>
         <protobuf.version>3.21.2</protobuf.version>
         <protoc.version>3.19.2</protoc.version>
         <kafka.version>3.2.0</kafka.version>

--- a/src/main/java/io/conduit/CombinedSchemaProvider.java
+++ b/src/main/java/io/conduit/CombinedSchemaProvider.java
@@ -34,13 +34,13 @@ public class CombinedSchemaProvider implements SchemaProvider {
 
     @Override
     public Schema provide(Record rec) {
-        if (!rec.hasPayload()) {
+        if (!rec.hasPayload() || !rec.getPayload().hasAfter()) {
             return null;
         }
-        if (rec.getPayload().hasStructuredData()) {
+        if (rec.getPayload().getAfter().hasStructuredData()) {
             return structSP.provide(rec);
         }
-        if (rec.getPayload().hasRawData()) {
+        if (rec.getPayload().getAfter().hasRawData()) {
             return rawDataSP.provide(rec);
         }
         return null;

--- a/src/main/java/io/conduit/CombinedSchemaProvider.java
+++ b/src/main/java/io/conduit/CombinedSchemaProvider.java
@@ -17,24 +17,21 @@
 package io.conduit;
 
 import io.conduit.grpc.Record;
+import lombok.AllArgsConstructor;
 import org.apache.kafka.connect.data.Schema;
 
 /**
  * A {@link SchemaProvider} implementation which combines the functionality of
  * a {@link RawDataSchemaProvider} and a {@link StructSchemaProvider}.
  */
+@AllArgsConstructor
 public class CombinedSchemaProvider implements SchemaProvider {
     private final RawDataSchemaProvider rawDataSP;
     private final StructSchemaProvider structSP;
 
-    public CombinedSchemaProvider(String name, Schema overrides) {
-        this.rawDataSP = new RawDataSchemaProvider(name, overrides);
-        this.structSP = new StructSchemaProvider(name, overrides);
-    }
-
     @Override
     public Schema provide(Record rec) {
-        if (!rec.hasPayload() || !rec.getPayload().hasAfter()) {
+        if (rec == null || !rec.hasPayload() || !rec.getPayload().hasAfter()) {
             return null;
         }
         if (rec.getPayload().getAfter().hasStructuredData()) {

--- a/src/main/java/io/conduit/DefaultDestinationStream.java
+++ b/src/main/java/io/conduit/DefaultDestinationStream.java
@@ -35,14 +35,14 @@ import org.apache.kafka.connect.sink.SinkTask;
 /**
  * A {@link io.grpc.stub.StreamObserver} implementation which exposes a Kafka connector sink task through a gRPC stream.
  */
-public class DestinationStream implements StreamObserver<Destination.Run.Request> {
+public class DefaultDestinationStream implements StreamObserver<Destination.Run.Request> {
     private final SinkTask task;
     private final SchemaProvider schemaProvider;
     private final StreamObserver<Destination.Run.Response> responseObserver;
 
-    public DestinationStream(SinkTask task,
-                             SchemaProvider schemaProvider,
-                             StreamObserver<Destination.Run.Response> responseObserver) {
+    public DefaultDestinationStream(SinkTask task,
+                                    SchemaProvider schemaProvider,
+                                    StreamObserver<Destination.Run.Response> responseObserver) {
         this.task = task;
         this.schemaProvider = schemaProvider;
         this.responseObserver = responseObserver;

--- a/src/main/java/io/conduit/DefaultSourceStream.java
+++ b/src/main/java/io/conduit/DefaultSourceStream.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2022 Meroxa, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.conduit;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.function.Function;
+
+import com.google.protobuf.ByteString;
+import io.conduit.grpc.Record;
+import io.conduit.grpc.Source;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import lombok.SneakyThrows;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTask;
+
+/**
+ * A {@link io.grpc.stub.StreamObserver} implementation which exposes a Kafka connector source task
+ * through a gRPC stream.
+ */
+public class DefaultSourceStream implements SourceStream {
+    private final SourceTask task;
+    private final StreamObserver<Source.Run.Response> responseObserver;
+    private boolean shouldRun = true;
+
+    private final Queue<SourceRecord> buffer = new LinkedList<>();
+    private final Function<SourceRecord, Record.Builder> transformer;
+    private final SourcePosition position;
+
+    public DefaultSourceStream(SourceTask task,
+                               SourcePosition position,
+                               StreamObserver<Source.Run.Response> responseObserver,
+                               Function<SourceRecord, Record.Builder> transformer) {
+        this.task = task;
+        this.position = position;
+        this.responseObserver = responseObserver;
+        this.transformer = transformer;
+    }
+
+    @Override
+    public void run() {
+        while (shouldRun) {
+            try {
+                if (buffer.isEmpty()) {
+                    fillBuffer();
+                }
+                SourceRecord rec = buffer.poll();
+                // We may get so-called tombstone records, i.e. records with a null payload.
+                // This can happen when records are deleted, for example.
+                // This is used in Kafka Connect internally, more precisely for log compaction in Kafka.
+                // For more info: https://kafka.apache.org/documentation/#compaction
+                if (rec.value() != null) {
+                    responseObserver.onNext(responseWith(rec));
+                }
+            } catch (Exception e) {
+                Logger.get().error("Couldn't write record.", e);
+                responseObserver.onError(
+                        Status.INTERNAL
+                                .withDescription("couldn't read record: " + e.getMessage())
+                                .withCause(e)
+                                .asException()
+                );
+            }
+        }
+        Logger.get().info("SourceStream loop stopped.");
+    }
+
+    @Override
+    public void onNext(Source.Run.Request value) {
+        // todo Acknowledging record not implemented yet...
+        // See: https://github.com/ConduitIO/conduit-kafka-connect-wrapper/issues/59
+    }
+
+    @SneakyThrows
+    private void fillBuffer() {
+        List<SourceRecord> polled = task.poll();
+        while (Utils.isEmpty(polled)) {
+            polled = task.poll();
+        }
+        buffer.addAll(polled);
+    }
+
+    @SneakyThrows
+    private Source.Run.Response responseWith(SourceRecord rec) {
+        position.add(rec.sourcePartition(), rec.sourceOffset());
+
+        Record.Builder conduitRec = transformer.apply(rec)
+                .setPosition(position.asByteString());
+
+        return Source.Run.Response.newBuilder()
+                .setRecord(conduitRec)
+                .build();
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        Logger.get().error("Experienced an error.", t);
+        stop();
+        responseObserver.onError(
+                Status.INTERNAL.withDescription("Error: " + t.getMessage()).withCause(t).asException()
+        );
+    }
+
+    @Override
+    public void onCompleted() {
+        Logger.get().info("Completed.");
+        stop();
+        responseObserver.onCompleted();
+    }
+
+    private void stop() {
+        Logger.get().info("Stopping...");
+        shouldRun = false;
+    }
+
+    /**
+     * Starts this stream. The method is not blocking -- the actual work is done in a separate thread.
+     */
+    public void startAsync() {
+        Thread thread = new Thread(this);
+        thread.setUncaughtExceptionHandler((t, e) -> {
+            Logger.get().error("Uncaught exception for thread {}.", t.getName(), e);
+            onError(e);
+        });
+        thread.start();
+    }
+
+    @Override
+    public ByteString lastRead() {
+        return position.asByteString();
+    }
+}

--- a/src/main/java/io/conduit/DestinationService.java
+++ b/src/main/java/io/conduit/DestinationService.java
@@ -33,7 +33,7 @@ public class DestinationService extends DestinationPluginGrpc.DestinationPluginI
     private final TaskFactory taskFactory;
     private SinkTask task;
     private Map<String, String> config;
-    private DestinationStream runStream;
+    private DefaultDestinationStream runStream;
     private boolean started;
     private SchemaProvider schemaProvider;
 
@@ -117,7 +117,7 @@ public class DestinationService extends DestinationPluginGrpc.DestinationPluginI
 
     @Override
     public StreamObserver<Destination.Run.Request> run(StreamObserver<Destination.Run.Response> responseObserver) {
-        this.runStream = new DestinationStream(task, schemaProvider, responseObserver);
+        this.runStream = new DefaultDestinationStream(task, schemaProvider, responseObserver);
         return runStream;
     }
 

--- a/src/main/java/io/conduit/DestinationService.java
+++ b/src/main/java/io/conduit/DestinationService.java
@@ -87,7 +87,10 @@ public class DestinationService extends DestinationPluginGrpc.DestinationPluginI
                 throw new IllegalArgumentException("Schema name not provided");
             }
 
-            return new CombinedSchemaProvider(name, config.getOverrides());
+            return new CombinedSchemaProvider(
+                    new RawDataSchemaProvider(name, config.getOverrides()),
+                    new StructSchemaProvider(name, config.getOverrides())
+            );
         }
         // No schema information provided, so no schema is to be used.
         return new FixedSchemaProvider(null);

--- a/src/main/java/io/conduit/OpenCdc.java
+++ b/src/main/java/io/conduit/OpenCdc.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Meroxa, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.conduit;
 
 public class OpenCdc {

--- a/src/main/java/io/conduit/OpenCdc.java
+++ b/src/main/java/io/conduit/OpenCdc.java
@@ -1,0 +1,9 @@
+package io.conduit;
+
+public class OpenCdc {
+    /**
+     * CreatedAt can contain the time when the record was created in the 3rd party system.
+     * The expected format is a unix timestamp in nanoseconds.
+     */
+    public static String MetadataCreatedAt = "opencdc.createdAt";
+}

--- a/src/main/java/io/conduit/OpenCdcMetadata.java
+++ b/src/main/java/io/conduit/OpenCdcMetadata.java
@@ -16,10 +16,13 @@
 
 package io.conduit;
 
-public class OpenCdc {
+/**
+ * Contains OpenCDC metadata constants.
+ */
+public class OpenCdcMetadata {
     /**
      * CreatedAt can contain the time when the record was created in the 3rd party system.
      * The expected format is a unix timestamp in nanoseconds.
      */
-    public static String MetadataCreatedAt = "opencdc.createdAt";
+    public static String CREATED_AT = "opencdc.createdAt";
 }

--- a/src/main/java/io/conduit/OpenCdcMetadata.java
+++ b/src/main/java/io/conduit/OpenCdcMetadata.java
@@ -19,7 +19,10 @@ package io.conduit;
 /**
  * Contains OpenCDC metadata constants.
  */
-public class OpenCdcMetadata {
+public final class OpenCdcMetadata {
+    private OpenCdcMetadata() {
+
+    }
     /**
      * CreatedAt can contain the time when the record was created in the 3rd party system.
      * The expected format is a unix timestamp in nanoseconds.

--- a/src/main/java/io/conduit/OpenCdcMetadata.java
+++ b/src/main/java/io/conduit/OpenCdcMetadata.java
@@ -28,5 +28,5 @@ public final class OpenCdcMetadata {
      * CreatedAt can contain the time when the record was created in the 3rd party system.
      * The expected format is a unix timestamp in nanoseconds.
      */
-    public static String CREATED_AT = "opencdc.createdAt";
+    public static String READ_AT = "opencdc.readAt";
 }

--- a/src/main/java/io/conduit/OpenCdcMetadata.java
+++ b/src/main/java/io/conduit/OpenCdcMetadata.java
@@ -23,6 +23,7 @@ public final class OpenCdcMetadata {
     private OpenCdcMetadata() {
 
     }
+
     /**
      * CreatedAt can contain the time when the record was created in the 3rd party system.
      * The expected format is a unix timestamp in nanoseconds.

--- a/src/main/java/io/conduit/RawDataSchemaProvider.java
+++ b/src/main/java/io/conduit/RawDataSchemaProvider.java
@@ -35,13 +35,13 @@ public class RawDataSchemaProvider implements SchemaProvider {
 
     @Override
     public Schema provide(Record rec) {
-        if (rec == null || !rec.hasPayload()) {
+        if (rec == null || !rec.hasPayload() || !rec.getPayload().hasAfter()) {
             return null;
         }
-        if (!rec.getPayload().hasRawData()) {
+        if (!rec.getPayload().getAfter().hasRawData()) {
             throw new IllegalArgumentException("Record has no raw data.");
         }
-        JsonNode json = parseJson(rec.getPayload().getRawData().toByteArray());
+        JsonNode json = parseJson(rec.getPayload().getAfter().getRawData().toByteArray());
         if (json == null) {
             return SchemaBuilder.bytes().name(name).optional();
         }

--- a/src/main/java/io/conduit/SourceStream.java
+++ b/src/main/java/io/conduit/SourceStream.java
@@ -16,127 +16,21 @@
 
 package io.conduit;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Queue;
-import java.util.function.Function;
-
-import io.conduit.grpc.Record;
+import com.google.protobuf.ByteString;
 import io.conduit.grpc.Source;
-import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
-import lombok.SneakyThrows;
-import org.apache.kafka.connect.source.SourceRecord;
-import org.apache.kafka.connect.source.SourceTask;
 
 /**
- * A {@link io.grpc.stub.StreamObserver} implementation which exposes a Kafka connector source task
- * through a gRPC stream.
+ * A <code>SourceStream</code> represents a stream of records from a Conduit source.
  */
-public class SourceStream implements StreamObserver<Source.Run.Request>, Runnable {
-    private final SourceTask task;
-    private final StreamObserver<Source.Run.Response> responseObserver;
-    private boolean shouldRun = true;
-
-    private final Queue<SourceRecord> buffer = new LinkedList<>();
-    private final Function<SourceRecord, Record.Builder> transformer;
-    private final SourcePosition position;
-
-    public SourceStream(SourceTask task,
-                        SourcePosition position,
-                        StreamObserver<Source.Run.Response> responseObserver,
-                        Function<SourceRecord, Record.Builder> transformer) {
-        this.task = task;
-        this.position = position;
-        this.responseObserver = responseObserver;
-        this.transformer = transformer;
-    }
-
-    @Override
-    public void run() {
-        while (shouldRun) {
-            try {
-                if (buffer.isEmpty()) {
-                    fillBuffer();
-                }
-                SourceRecord rec = buffer.poll();
-                // We may get so-called tombstone records, i.e. records with a null payload.
-                // This can happen when records are deleted, for example.
-                // This is used in Kafka Connect internally, more precisely for log compaction in Kafka.
-                // For more info: https://kafka.apache.org/documentation/#compaction
-                if (rec.value() != null) {
-                    responseObserver.onNext(responseWith(rec));
-                }
-            } catch (Exception e) {
-                Logger.get().error("Couldn't write record.", e);
-                responseObserver.onError(
-                        Status.INTERNAL
-                                .withDescription("couldn't read record: " + e.getMessage())
-                                .withCause(e)
-                                .asException()
-                );
-            }
-        }
-        Logger.get().info("SourceStream loop stopped.");
-    }
-
-    @Override
-    public void onNext(Source.Run.Request value) {
-        // todo Acknowledging record not implemented yet...
-        // See: https://github.com/ConduitIO/conduit-kafka-connect-wrapper/issues/59
-    }
-
-    @SneakyThrows
-    private void fillBuffer() {
-        List<SourceRecord> polled = task.poll();
-        while (Utils.isEmpty(polled)) {
-            polled = task.poll();
-        }
-        buffer.addAll(polled);
-    }
-
-    @SneakyThrows
-    private Source.Run.Response responseWith(SourceRecord rec) {
-        position.add(rec.sourcePartition(), rec.sourceOffset());
-
-        Record.Builder conduitRec = transformer.apply(rec)
-                .setPosition(position.asByteString());
-
-        return Source.Run.Response.newBuilder()
-                .setRecord(conduitRec)
-                .build();
-    }
-
-    @Override
-    public void onError(Throwable t) {
-        Logger.get().error("Experienced an error.", t);
-        stop();
-        responseObserver.onError(
-                Status.INTERNAL.withDescription("Error: " + t.getMessage()).withCause(t).asException()
-        );
-    }
-
-    @Override
-    public void onCompleted() {
-        Logger.get().info("Completed.");
-        stop();
-        responseObserver.onCompleted();
-    }
-
-    private void stop() {
-        Logger.get().info("Stopping...");
-        shouldRun = false;
-    }
+public interface SourceStream extends StreamObserver<Source.Run.Request>, Runnable {
+    /**
+     * Start this stream asynchronously.
+     */
+    void startAsync();
 
     /**
-     * Starts this stream. The method is not blocking -- the actual work is done in a separate thread.
+     * Returns the position of the last read by this source.
      */
-    public void start() {
-        Thread thread = new Thread(this);
-        thread.setUncaughtExceptionHandler((t, e) -> {
-            Logger.get().error("Uncaught exception for thread {}.", t.getName(), e);
-            onError(e);
-        });
-        thread.start();
-    }
+    ByteString lastRead();
 }

--- a/src/main/java/io/conduit/StructSchemaProvider.java
+++ b/src/main/java/io/conduit/StructSchemaProvider.java
@@ -34,13 +34,13 @@ public class StructSchemaProvider implements SchemaProvider {
 
     @Override
     public Schema provide(Record rec) {
-        if (!rec.hasPayload()) {
+        if (!rec.hasPayload() || !rec.getPayload().hasAfter()) {
             return null;
         }
-        if (!rec.getPayload().hasStructuredData()) {
+        if (!rec.getPayload().getAfter().hasStructuredData()) {
             throw new IllegalArgumentException("Record has no structured payload.");
         }
-        return schemaForStruct(rec.getPayload().getStructuredData());
+        return schemaForStruct(rec.getPayload().getAfter().getStructuredData());
     }
 
     private Schema schemaForStruct(Struct struct) {

--- a/src/main/java/io/conduit/Transformations.java
+++ b/src/main/java/io/conduit/Transformations.java
@@ -55,7 +55,7 @@ public class Transformations {
                 .setKey(getKey(sourceRecord))
                 .setPayload(getPayload(sourceRecord))
                 // we need nanoseconds here
-                .putMetadata(OpenCdc.MetadataCreatedAt, String.valueOf(System.currentTimeMillis() * 1_000_000));
+                .putMetadata(OpenCdcMetadata.CREATED_AT, String.valueOf(System.currentTimeMillis() * 1_000_000));
     }
 
     private static Change getPayload(SourceRecord sourceRecord) {

--- a/src/main/java/io/conduit/Transformations.java
+++ b/src/main/java/io/conduit/Transformations.java
@@ -24,6 +24,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.JsonFormat;
+import io.conduit.grpc.Change;
 import io.conduit.grpc.Data;
 import io.conduit.grpc.Record;
 import lombok.SneakyThrows;
@@ -31,6 +32,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;
 
 import static io.conduit.Utils.jsonConvSchemaless;
+import static io.conduit.grpc.Opencdc.metadataCreatedAt;
 
 /**
  * A class holding common transformations between Conduit and Kafka connect data types.
@@ -54,20 +56,12 @@ public class Transformations {
         return Record.newBuilder()
                 .setKey(getKey(sourceRecord))
                 .setPayload(getPayload(sourceRecord))
-                .setCreatedAt(currentTimestamp());
+                .putMetadata("opencdc.createdAt", String.valueOf(System.currentTimeMillis()));
     }
 
-    private static Timestamp currentTimestamp() {
-        long millis = System.currentTimeMillis();
-        return Timestamp.newBuilder()
-                .setSeconds(millis / 1000)
-                .setNanos((int) (millis % 1000) * 1000)
-                .build();
-    }
-
-    private static Data getPayload(SourceRecord sourceRecord) {
+    private static Change getPayload(SourceRecord sourceRecord) {
         if (sourceRecord.valueSchema() != null) {
-            return schemaValueToData(sourceRecord.valueSchema(), sourceRecord.value());
+            return schemaValueToChange(sourceRecord.valueSchema(), sourceRecord.value());
         }
         throw new UnsupportedOperationException("payloads without schemas not supported yet");
     }
@@ -80,6 +74,13 @@ public class Transformations {
             return schemaValueToData(sourceRecord.keySchema(), sourceRecord.key());
         }
         throw new UnsupportedOperationException("keys without schemas not supported yet");
+    }
+
+    @SneakyThrows
+    private static Change schemaValueToChange(Schema schema, Object value) {
+        return Change.newBuilder()
+                .setAfter(schemaValueToData(schema, value))
+                .build();
     }
 
     @SneakyThrows
@@ -115,11 +116,11 @@ public class Transformations {
         if (rec == null) {
             throw new IllegalArgumentException("record is null");
         }
-        if (!rec.hasPayload()) {
-            throw new IllegalArgumentException("record has no payload");
+        if (!rec.hasPayload() || !rec.getPayload().hasAfter()) {
+            throw new IllegalArgumentException("record has no payload or has no after data");
         }
 
-        if (rec.getPayload().hasStructuredData()) {
+        if (rec.getPayload().getAfter().hasStructuredData()) {
             return Transformations.parseStructured(rec, schema);
         } else {
             return Transformations.parseRaw(rec, schema);
@@ -136,14 +137,14 @@ public class Transformations {
         // however, for the first version of the plugin we're looking for making it work first.
         // See: https://github.com/ConduitIO/conduit-kafka-connect-wrapper/issues/58
         byte[] bytes = JsonFormat.printer()
-                .print(rec.getPayload().getStructuredData())
+                .print(rec.getPayload().getAfter().getStructuredData())
                 .getBytes(StandardCharsets.UTF_8);
         return jsonToStruct(bytes, schema);
     }
 
     @SneakyThrows
     private static Object parseRaw(Record rec, Schema schema) {
-        byte[] content = rec.getPayload().getRawData().toByteArray();
+        byte[] content = rec.getPayload().getAfter().getRawData().toByteArray();
         if (schema == null) {
             return content;
         }

--- a/src/main/java/io/conduit/Transformations.java
+++ b/src/main/java/io/conduit/Transformations.java
@@ -55,7 +55,7 @@ public class Transformations {
                 .setKey(getKey(sourceRecord))
                 .setPayload(getPayload(sourceRecord))
                 // we need nanoseconds here
-                .putMetadata(OpenCdcMetadata.CREATED_AT, String.valueOf(System.currentTimeMillis() * 1_000_000));
+                .putMetadata(OpenCdcMetadata.READ_AT, String.valueOf(System.currentTimeMillis() * 1_000_000));
     }
 
     private static Change getPayload(SourceRecord sourceRecord) {

--- a/src/main/java/io/conduit/Transformations.java
+++ b/src/main/java/io/conduit/Transformations.java
@@ -16,6 +16,9 @@
 
 package io.conduit;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Struct;
@@ -26,9 +29,6 @@ import io.conduit.grpc.Record;
 import lombok.SneakyThrows;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 import static io.conduit.Utils.jsonConvSchemaless;
 
@@ -55,7 +55,7 @@ public class Transformations {
                 .setKey(getKey(sourceRecord))
                 .setPayload(getPayload(sourceRecord))
                 // we need nanoseconds here
-                .putMetadata(OpenCdc.MetadataCreatedAt, String.valueOf(System.currentTimeMillis()*1_000_000));
+                .putMetadata(OpenCdc.MetadataCreatedAt, String.valueOf(System.currentTimeMillis() * 1_000_000));
     }
 
     private static Change getPayload(SourceRecord sourceRecord) {

--- a/src/main/java/io/conduit/Transformations.java
+++ b/src/main/java/io/conduit/Transformations.java
@@ -16,13 +16,9 @@
 
 package io.conduit;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Struct;
-import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.JsonFormat;
 import io.conduit.grpc.Change;
 import io.conduit.grpc.Data;
@@ -31,8 +27,10 @@ import lombok.SneakyThrows;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import static io.conduit.Utils.jsonConvSchemaless;
-import static io.conduit.grpc.Opencdc.metadataCreatedAt;
 
 /**
  * A class holding common transformations between Conduit and Kafka connect data types.
@@ -56,7 +54,8 @@ public class Transformations {
         return Record.newBuilder()
                 .setKey(getKey(sourceRecord))
                 .setPayload(getPayload(sourceRecord))
-                .putMetadata("opencdc.createdAt", String.valueOf(System.currentTimeMillis()));
+                // we need nanoseconds here
+                .putMetadata(OpenCdc.MetadataCreatedAt, String.valueOf(System.currentTimeMillis()*1_000_000));
     }
 
     private static Change getPayload(SourceRecord sourceRecord) {

--- a/src/main/proto/connector.proto
+++ b/src/main/proto/connector.proto
@@ -5,47 +5,95 @@ package connector.v1;
 option java_multiple_files = true;
 option java_package = "io.conduit.grpc";
 
-import "google/protobuf/timestamp.proto";
-import "google/protobuf/struct.proto";
+import "google/protobuf/descriptor.proto";
+import "opencdc.proto";
 
-message Record {
-  bytes position = 1;
-  map<string, string> metadata = 2;
-  google.protobuf.Timestamp created_at = 3;
-  Data key = 4;
-  Data payload = 5;
+option (metadata_conduit_plugin_name) = "conduit.plugin.name";
+option (metadata_conduit_plugin_version) = "conduit.plugin.version";
+
+// We are (ab)using custom file options to define constants.
+// See https://github.com/protocolbuffers/protobuf/issues/3520#issuecomment-323613839
+extend google.protobuf.FileOptions {
+  string metadata_conduit_plugin_name = 20000;
+  string metadata_conduit_plugin_version = 20001;
 }
 
-message Data {
-  oneof data {
-    bytes raw_data = 1;
-    google.protobuf.Struct structured_data = 2;
-  }
-}
-
+// SourcePlugin is responsible for fetching records from 3rd party resources and
+// sending them to Conduit.
 service SourcePlugin {
+  // Configure is the first function to be called in a plugin. It provides the
+  // plugin with the configuration that needs to be validated and stored. In
+  // case the configuration is not valid it should return an error status.
   rpc Configure(Source.Configure.Request) returns (Source.Configure.Response);
+  // Start is called after Configure to signal the plugin it can prepare to
+  // start producing records. If needed, the plugin should open connections in
+  // this function. The position parameter will contain the position of the
+  // last record that was successfully processed. The Source should therefore
+  // start producing records after this position.
   rpc Start(Source.Start.Request) returns (Source.Start.Response);
+  // Run will open a bidirectional stream between Conduit and the plugin.
+  // The plugin is responsible for fetching records from 3rd party resources
+  // and sending them as responses to Conduit. Conduit will process the
+  // records asynchronously and send acknowledgments back to the plugin to
+  // signal that a record at a certain position was processed. Acknowledgments
+  // will be sent back to the connector in the same order as the records
+  // produced by the connector. If a record could not be processed by Conduit,
+  // the stream will be closed without an acknowledgment being sent back to the
+  // connector.
   rpc Run(stream Source.Run.Request) returns (stream Source.Run.Response);
+  // Stop signals to the plugin to stop retrieving new records and flush any
+  // records that might be cached into the stream. It should block until it can
+  // determine the last record that will be sent to the stream and return the
+  // position of the last record. Conduit will keep the stream open until it
+  // receives the last record and sends back any outstanding acknowledgments.
+  // If Conduit did not send an acknowledgment for a record after the stream is
+  // closed, it should be interpreted as a negative acknowledgment.
   rpc Stop(Source.Stop.Request) returns (Source.Stop.Response);
+  // Teardown signals to the plugin that there will be no more calls to any
+  // other function. After Teardown returns, the plugin should be ready for a
+  // graceful shutdown.
   rpc Teardown(Source.Teardown.Request) returns (Source.Teardown.Response);
 }
 
+// DestinationPlugin is responsible for writing records to 3rd party resources.
 service DestinationPlugin {
+  // Configure is the first function to be called in a plugin. It provides the
+  // plugin with the configuration that needs to be validated and stored. In
+  // case the configuration is not valid it should return an error status.
   rpc Configure(Destination.Configure.Request) returns (Destination.Configure.Response);
+  // Start is called after Configure to signal the plugin it can prepare to
+  // start writing records. If needed, the plugin should open connections in
+  // this function.
   rpc Start(Destination.Start.Request) returns (Destination.Start.Response);
+  // Run will open a bidirectional stream between Conduit and the plugin.
+  // Conduit will be streaming records to the plugin that should be written
+  // to the 3rd party resource. The plugin is responsible for sending
+  // acknowledgments back to Conduit once a record has been processed. The
+  // acknowledgment should contain an error in case a record could not be
+  // successfully processed. The stream should still stay open in case Conduit
+  // is able to recover from the error and the pipeline keeps running.
   rpc Run(stream Destination.Run.Request) returns (stream Destination.Run.Response);
+  // Stop signals to the plugin that the record with the specified position is
+  // the last one and no more records will be written to the stream after it.
+  // Once the plugin receives the last record it should flush any records that
+  // might be cached and not yet written to the 3rd party resource.
   rpc Stop(Destination.Stop.Request) returns (Destination.Stop.Response);
+  // Teardown signals to the plugin that there will be no more calls to any
+  // other function. After Teardown returns, the plugin should be ready for a
+  // graceful shutdown.
   rpc Teardown(Destination.Teardown.Request) returns (Destination.Teardown.Response);
 }
 
+// SpecifierPlugin is responsible for returning the plugin specification.
 service SpecifierPlugin {
+  // Specify should return the plugin specification.
   rpc Specify(Specifier.Specify.Request) returns (Specifier.Specify.Response);
 }
 
 message Source {
   message Configure {
     message Request {
+      // Config contains the raw plugin settings.
       map<string, string> config = 1;
     }
     message Response {}
@@ -53,6 +101,9 @@ message Source {
 
   message Start {
     message Request {
+      // This is the position of the last record that was successfully
+      // processed. The Source should start producing records after this
+      // position.
       bytes position = 1;
     }
     message Response {}
@@ -60,16 +111,27 @@ message Source {
 
   message Run {
     message Request {
+      // This is the position of the record that was successfully
+      // processed.
       bytes ack_position = 1;
     }
     message Response {
-      Record record = 1;
+      // Record contains the OpenCDC record read by the source from the 3rd
+      // party resource.
+      opencdc.v1.Record record = 1;
     }
   }
 
   message Stop {
     message Request {}
-    message Response {}
+    message Response {
+      // This is the position of the last record in the stream, Conduit
+      // won't process records after this position anymore. After the
+      // record with this position is received by Conduit and all
+      // outstanding acknowledgments were delivered to the connector, the
+      // stream will be closed.
+      bytes last_position = 1;
+    }
   }
 
   message Teardown {
@@ -81,6 +143,7 @@ message Source {
 message Destination {
   message Configure {
     message Request {
+      // Config contains the raw plugin settings.
       map<string, string> config = 1;
     }
     message Response {}
@@ -93,16 +156,27 @@ message Destination {
 
   message Run {
     message Request {
-      Record record = 1;
+      // Record contains the OpenCDC record that should be written to the 3rd
+      // party resource.
+      opencdc.v1.Record record = 1;
     }
     message Response {
+      // This is the position of the record that was processed.
       bytes ack_position = 1;
+      // Error should be empty if the record was successfully processed or
+      // should contain a descriptive message in case the record
+      // processing failed.
       string error = 2;
     }
   }
 
   message Stop {
-    message Request {}
+    message Request {
+      // This is the position of the last record that was sent into the stream.
+      // Conduit won't send any records after a record with this position is
+      // received.
+      bytes last_position = 1;
+    }
     message Response {}
   }
 
@@ -116,19 +190,38 @@ message Specifier {
   message Specify {
     message Request {}
     message Response {
+      // Name is the name of the plugin.
       string name = 1;
+      // Summary is a brief description of the plugin and what it does,
+      // ideally not longer than one sentence.
       string summary = 2;
+      // Description is a longer form field, appropriate for README-like
+      // text that the author can provide for documentation about the
+      // usage of the plugin.
       string description = 3;
+      // Version string. Should follow semantic versioning and use the "v"
+      // prefix (e.g. v1.23.4).
       string version = 4;
+      // Author declares the entity that created or maintains this plugin.
       string author = 5;
+      // A map that describes parameters available for configuring the
+      // destination plugin.
       map<string, Parameter> destination_params = 6;
+      // A map that describes parameters available for configuring the
+      // source plugin.
       map<string, Parameter> source_params = 7;
     }
   }
 
+  // Parameter describes a single config parameter.
   message Parameter {
+    // Default is the default value of the parameter. If there is no default
+    // value use an empty string.
     string default = 1;
+    // Required defines whether the parameter has to be provided when
+    // configuring the plugin.
     bool required = 2;
+    // Description explains what the parameter does and how to configure it.
     string description = 3;
   }
 }

--- a/src/main/proto/opencdc.proto
+++ b/src/main/proto/opencdc.proto
@@ -1,0 +1,98 @@
+syntax = "proto3";
+
+package opencdc.v1;
+
+option java_multiple_files = true;
+option java_package = "io.conduit.grpc";
+
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/struct.proto";
+
+// OpenCDC version is a constant that should be used as the value in the
+// metadata field opencdc.version. It ensures the OpenCDC format version can be
+// easily identified in case the record gets marshaled into a different untyped
+// format (e.g. JSON).
+option (opencdc_version) = "v1";
+
+// Version contains the version of the OpenCDC format (e.g. "v1"). This field
+// exists to ensure the OpenCDC format version can be easily identified in case
+// the record gets marshaled into a different untyped format (e.g. JSON).
+option (metadata_version) = "opencdc.version";
+// CreatedAt can contain the time when the record was created in the 3rd party
+// system. The expected format is a unix timestamp in nanoseconds.
+option (metadata_created_at) = "opencdc.createdAt";
+// ReadAt can contain the time when the record was read from the 3rd party
+// system. The expected format is a unix timestamp in nanoseconds.
+option (metadata_read_at) = "opencdc.readAt";
+
+// We are (ab)using custom file options to define constants.
+// See https://github.com/protocolbuffers/protobuf/issues/3520#issuecomment-323613839
+extend google.protobuf.FileOptions {
+  string opencdc_version = 9999;
+
+  string metadata_version = 10000;
+  string metadata_created_at = 10001;
+  string metadata_read_at = 10002;
+}
+
+// Operation defines what triggered the creation of a record.
+enum Operation {
+  OPERATION_UNSPECIFIED = 0;
+  // Records with operation create contain data of a newly created entity.
+  OPERATION_CREATE = 1;
+  // Records with operation update contain data of an updated entity.
+  OPERATION_UPDATE = 2;
+  // Records with operation delete contain data of a deleted entity.
+  OPERATION_DELETE = 3;
+  // Records with operation snapshot contain data of a previously existing
+  // entity, fetched as part of a snapshot.
+  OPERATION_SNAPSHOT = 4;
+}
+
+// Record contains data about a single change event related to a single entity.
+message Record {
+  // Position uniquely identifies the record.
+  bytes position = 1;
+
+  // Operation defines what triggered the creation of a record. There are four
+  // possibilities: create, update, delete or snapshot. The first three
+  // operations are encountered during normal CDC operation, while "snapshot" is
+  // meant to represent records during an initial load. Depending on the
+  // operation, the record will contain either the payload before the change,
+  // after the change, or both (see field payload).
+  Operation operation = 2;
+
+  // Metadata contains optional information related to the record. Although the
+  // map can contain arbitrary keys, the standard provides a set of standard
+  // metadata fields (see options prefixed with metadata_*).
+  map<string, string> metadata = 3;
+
+  // Key represents a value that should identify the entity (e.g. database row).
+  Data key = 4;
+  // Payload holds the payload change (data before and after the operation
+  // occurred).
+  Change payload = 5;
+}
+
+// Change represents the data before and after the operation occurred.
+message Change {
+  // Before contains the data before the operation occurred. This field is
+  // optional and should only be populated for operations "update" and "delete"
+  // (if the system supports fetching the data before the operation).
+  Data before = 1;
+  // After contains the data after the operation occurred. This field should be
+  // populated for all operations except "delete".
+  Data after = 2;
+}
+
+// Data is used to represent the record key and payload. It can be either raw
+// data (byte array) or structured data (struct).
+message Data {
+  oneof data {
+    // Raw data contains unstructured data in form of a byte array.
+    bytes raw_data = 1;
+    // Structured data contains data in form of a struct with fields.
+    google.protobuf.Struct structured_data = 2;
+  }
+  // TODO schema will be added here in future iterations.
+}

--- a/src/test/java/io/conduit/BasePostgresIT.java
+++ b/src/test/java/io/conduit/BasePostgresIT.java
@@ -146,8 +146,8 @@ public abstract class BasePostgresIT {
         Record updated = captor.getAllValues().get(1).getRecord();
         assertKeyOk(1, updated);
 
-        assertTrue(updated.getPayload().hasStructuredData());
-        Struct struct = updated.getPayload().getStructuredData();
+        assertTrue(updated.getPayload().getAfter().hasStructuredData());
+        Struct struct = updated.getPayload().getAfter().getStructuredData();
         assertTrue(struct.getFieldsOrThrow("source").hasStructValue());
         assertTrue(struct.getFieldsOrThrow("before").hasStructValue());
         assertTrue(struct.getFieldsOrThrow("after").hasNullValue());

--- a/src/test/java/io/conduit/CombinedSchemaProviderTest.java
+++ b/src/test/java/io/conduit/CombinedSchemaProviderTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 Meroxa, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.conduit;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Struct;
+import io.conduit.grpc.Change;
+import io.conduit.grpc.Data;
+import io.conduit.grpc.Record;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CombinedSchemaProviderTest {
+    private CombinedSchemaProvider underTest;
+    @Mock
+    private RawDataSchemaProvider rawSP;
+    @Mock
+    private StructSchemaProvider structSP;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new CombinedSchemaProvider(rawSP, structSP);
+    }
+
+    @Test
+    public void testNullRecord() {
+        assertNull(underTest.provide(null));
+    }
+
+    @Test
+    public void testNoPayload() {
+        assertNull(underTest.provide(Record.newBuilder().build()));
+    }
+
+    @Test
+    public void testNoAfter() {
+        Record rec = Record.newBuilder()
+                .setPayload(Change.newBuilder().build())
+                .build();
+        assertNull(underTest.provide(rec));
+    }
+
+    @Test
+    public void testRaw() {
+        Change payload = Change.newBuilder()
+                .setAfter(Data.newBuilder().setRawData(ByteString.copyFromUtf8("raw data")).build())
+                .build();
+        Record rec = Record.newBuilder()
+                .setPayload(payload)
+                .build();
+
+        Schema expected = mock(Schema.class);
+        when(rawSP.provide(rec)).thenReturn(expected);
+
+        Schema actual = underTest.provide(rec);
+        verify(rawSP).provide(rec);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testStruct() {
+        Struct struct = Struct.newBuilder().build();
+        Change payload = Change.newBuilder()
+                .setAfter(Data.newBuilder().setStructuredData(struct).build())
+                .build();
+        Record rec = Record.newBuilder()
+                .setPayload(payload)
+                .build();
+
+        Schema expected = mock(Schema.class);
+        when(structSP.provide(rec)).thenReturn(expected);
+
+        Schema actual = underTest.provide(rec);
+        verify(structSP).provide(rec);
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/io/conduit/DebeziumPgSourceIT.java
+++ b/src/test/java/io/conduit/DebeziumPgSourceIT.java
@@ -48,8 +48,8 @@ public class DebeziumPgSourceIT extends BasePostgresIT {
 
     @Override
     protected void assertNameUpdated(Record updated) {
-        assertTrue(updated.getPayload().hasStructuredData());
-        Struct struct = updated.getPayload().getStructuredData();
+        assertTrue(updated.getPayload().getAfter().hasStructuredData());
+        Struct struct = updated.getPayload().getAfter().getStructuredData();
         assertTrue(struct.getFieldsOrThrow("source").hasStructValue());
         assertTrue(struct.getFieldsOrThrow("before").hasNullValue());
         assertTrue(struct.getFieldsOrThrow("after").hasStructValue());
@@ -62,8 +62,8 @@ public class DebeziumPgSourceIT extends BasePostgresIT {
     protected void assertNewRecordOk(int index, Record rec) {
         assertKeyOk(index, rec);
 
-        assertTrue(rec.getPayload().hasStructuredData());
-        Struct struct = rec.getPayload().getStructuredData();
+        assertTrue(rec.getPayload().getAfter().hasStructuredData());
+        Struct struct = rec.getPayload().getAfter().getStructuredData();
         assertTrue(struct.getFieldsOrThrow("source").hasStructValue());
         assertTrue(struct.getFieldsOrThrow("before").hasNullValue());
         assertTrue(struct.getFieldsOrThrow("after").hasStructValue());

--- a/src/test/java/io/conduit/DestinationStreamTest.java
+++ b/src/test/java/io/conduit/DestinationStreamTest.java
@@ -1,15 +1,8 @@
 package io.conduit;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.UUID;
-import java.util.function.Consumer;
-
 import com.google.protobuf.ByteString;
-import com.google.protobuf.Timestamp;
-import io.conduit.grpc.Data;
-import io.conduit.grpc.Destination;
 import io.conduit.grpc.Record;
+import io.conduit.grpc.*;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.stub.StreamObserver;
@@ -25,6 +18,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collection;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static io.conduit.TestUtils.newRecordPayload;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
@@ -146,15 +144,9 @@ public class DestinationStreamTest {
     private Record newRecord() {
         return Record.newBuilder()
                 .setKey(Data.newBuilder().setRawData(ByteString.copyFromUtf8(UUID.randomUUID().toString())).build())
-                .setPayload(Data.newBuilder().setRawData(newRecordPayload()).build())
+                .setPayload(newRecordPayload())
                 .setPosition(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-                .setCreatedAt(Timestamp.newBuilder().setSeconds(123456).build())
+                .putMetadata(Opencdc.metadataCreatedAt.getDefaultValue(), "123456000000000")
                 .build();
-    }
-
-    private ByteString newRecordPayload() {
-        return ByteString.copyFromUtf8(
-                "{\"id\":123,\"name\":\"foobar\"}"
-        );
     }
 }

--- a/src/test/java/io/conduit/DestinationStreamTest.java
+++ b/src/test/java/io/conduit/DestinationStreamTest.java
@@ -65,7 +65,7 @@ public class DestinationStreamTest {
         assertNull(sinkRecord.valueSchema());
         assertEquals(record.getKey().getRawData().toStringUtf8(), sinkRecord.key());
         assertEquals(
-                record.getPayload().getRawData(),
+                record.getPayload().getAfter().getRawData(),
                 ByteString.copyFrom((byte[]) sinkRecord.value())
         );
 

--- a/src/test/java/io/conduit/DestinationStreamTest.java
+++ b/src/test/java/io/conduit/DestinationStreamTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class DestinationStreamTest {
-    private DestinationStream underTest;
+    private DefaultDestinationStream underTest;
     @Mock
     private SinkTask task;
     @Mock
@@ -43,12 +43,12 @@ public class DestinationStreamTest {
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.STRING_SCHEMA)
                 .build();
-        this.underTest = new DestinationStream(task, new FixedSchemaProvider(schema), streamObserver);
+        this.underTest = new DefaultDestinationStream(task, new FixedSchemaProvider(schema), streamObserver);
     }
 
     @Test
     public void testWriteRecordNoSchema() {
-        DestinationStream underTest = new DestinationStream(task, new FixedSchemaProvider(null), streamObserver);
+        DefaultDestinationStream underTest = new DefaultDestinationStream(task, new FixedSchemaProvider(null), streamObserver);
         Destination.Run.Request request = newRequest();
         Record record = request.getRecord();
 

--- a/src/test/java/io/conduit/JdbcPgSourceIT.java
+++ b/src/test/java/io/conduit/JdbcPgSourceIT.java
@@ -46,21 +46,21 @@ public class JdbcPgSourceIT extends BasePostgresIT {
 
     @Override
     protected void assertNameUpdated(Record updated) {
-        assertTrue(updated.getPayload().hasStructuredData());
+        assertTrue(updated.getPayload().getAfter().hasStructuredData());
         assertEquals(
                 "foobar",
-                updated.getPayload().getStructuredData().getFieldsOrThrow("name").getStringValue()
+                updated.getPayload().getAfter().getStructuredData().getFieldsOrThrow("name").getStringValue()
         );
     }
 
     @Override
     protected void assertNewRecordOk(int index, Record rec) {
-        assertTrue(rec.getPayload().hasStructuredData());
-        assertPayloadOk(index, rec.getPayload().getStructuredData());
+        assertTrue(rec.getPayload().getAfter().hasStructuredData());
+        assertPayloadOk(index, rec.getPayload().getAfter().getStructuredData());
     }
 
     @Override
     protected void assertKeyOk(int index, Record rec) {
-        assertEquals(index, rec.getPayload().getStructuredData().getFieldsOrThrow("id").getNumberValue());
+        assertEquals(index, rec.getPayload().getAfter().getStructuredData().getFieldsOrThrow("id").getNumberValue());
     }
 }

--- a/src/test/java/io/conduit/RawDataSchemaProviderTest.java
+++ b/src/test/java/io/conduit/RawDataSchemaProviderTest.java
@@ -1,15 +1,17 @@
 package io.conduit;
 
-import java.nio.charset.StandardCharsets;
-
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Struct;
+import io.conduit.grpc.Change;
 import io.conduit.grpc.Data;
 import io.conduit.grpc.Record;
 import org.apache.kafka.connect.data.Schema;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+
+import static io.conduit.TestUtils.newCreatedRecord;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class RawDataSchemaProviderTest {
@@ -30,10 +32,7 @@ public class RawDataSchemaProviderTest {
 
         Record record = Record.newBuilder()
                 .setKey(Data.newBuilder().setRawData(ByteString.copyFromUtf8("test-key")).build())
-                .setPayload(Data.newBuilder()
-                        .setRawData(ByteString.copyFromUtf8(json.toString()))
-                        .build()
-                ).build();
+                .setPayload(newCreatedRecord(json)).build();
 
         Schema result = underTest.provide(record);
 
@@ -63,10 +62,8 @@ public class RawDataSchemaProviderTest {
 
         Record record = Record.newBuilder()
                 .setKey(Data.newBuilder().setRawData(ByteString.copyFromUtf8("test-key")).build())
-                .setPayload(Data.newBuilder()
-                        .setRawData(ByteString.copyFromUtf8(json.toString()))
-                        .build()
-                ).build();
+                .setPayload(newCreatedRecord(json))
+                .build();
 
         Schema result = underTest.provide(record);
 
@@ -83,10 +80,8 @@ public class RawDataSchemaProviderTest {
         RawDataSchemaProvider underTest = new RawDataSchemaProvider("myschema", null);
         Record record = Record.newBuilder()
                 .setKey(Data.newBuilder().setRawData(ByteString.copyFromUtf8("test-key")).build())
-                .setPayload(Data.newBuilder()
-                        .setRawData(ByteString.copyFrom(new byte[]{11, 22, 33}))
-                        .build()
-                ).build();
+                .setPayload(newCreatedRecord(new byte[]{11, 22, 33}))
+                .build();
         Schema schema = underTest.provide(record);
         assertNotNull(schema);
         assertEquals("myschema", schema.name());
@@ -110,10 +105,11 @@ public class RawDataSchemaProviderTest {
     public void testStructPayload() {
         RawDataSchemaProvider underTest = new RawDataSchemaProvider("myschema", null);
         Record record = Record.newBuilder()
-                .setPayload(
-                        Data.newBuilder().setStructuredData(Struct.newBuilder().build()).build()
-                ).build();
+                .setPayload(newCreatedRecord(Struct.newBuilder().build()))
+                .build();
         var e = assertThrows(IllegalArgumentException.class, () -> underTest.provide(record));
         assertEquals("Record has no raw data.", e.getMessage());
     }
 }
+
+

--- a/src/test/java/io/conduit/SnowflakeDestinationIT.java
+++ b/src/test/java/io/conduit/SnowflakeDestinationIT.java
@@ -211,10 +211,10 @@ public class SnowflakeDestinationIT {
 
     // Checks if given records has the provided content and key (taken from the metadata string)
     private boolean matches(String content, String metadata, Record rec) throws JsonProcessingException {
-        if (rec.getPayload().hasRawData()) {
+        if (rec.getPayload().getAfter().hasRawData()) {
             return matchesRawJson(content, metadata, rec);
         }
-        if (rec.getPayload().hasStructuredData()) {
+        if (rec.getPayload().getAfter().hasStructuredData()) {
             return matchesStruct(content, metadata, rec);
         }
         throw new IllegalArgumentException("record without any payload");
@@ -223,7 +223,7 @@ public class SnowflakeDestinationIT {
     @SneakyThrows
     private boolean matchesStruct(String content, String metadata, Record rec) {
         var key = rec.getKey().getRawData().toStringUtf8();
-        var payloadStruct = rec.getPayload().getStructuredData();
+        var payloadStruct = rec.getPayload().getAfter().getStructuredData();
 
         var contentStruct = Struct.newBuilder();
         JsonFormat.parser().merge(content, contentStruct);
@@ -235,7 +235,7 @@ public class SnowflakeDestinationIT {
     @SneakyThrows
     private boolean matchesRawJson(String content, String metadata, Record rec) {
         var key = rec.getKey().getRawData().toStringUtf8();
-        var payloadJson = mapper.readTree(rec.getPayload().getRawData().toStringUtf8());
+        var payloadJson = mapper.readTree(rec.getPayload().getAfter().getRawData().toStringUtf8());
         var contentJson = mapper.readTree(content);
         var metaJson = mapper.readTree(metadata);
         return payloadJson.equals(contentJson) && metaJson.path("key").asText().equals(key);

--- a/src/test/java/io/conduit/SourceStreamTest.java
+++ b/src/test/java/io/conduit/SourceStreamTest.java
@@ -39,14 +39,14 @@ public class SourceStreamTest {
     @Test
     @DisplayName("When SourceStream is created, the underlying SourceTask starts being polled.")
     public void testRunAfterInit() throws InterruptedException {
-        new SourceStream(task, position, streamObserver, transformer).start();
+        new DefaultSourceStream(task, position, streamObserver, transformer).startAsync();
         verify(task, timeout(50).atLeastOnce()).poll();
     }
 
     @Test
     @DisplayName("When onCompleted is called, the underlying streams's onCompleted is called.")
     public void testOnCompleted() {
-        var underTest = new SourceStream(task, position, streamObserver, transformer);
+        var underTest = new DefaultSourceStream(task, position, streamObserver, transformer);
         underTest.onCompleted();
 
         verify(streamObserver).onCompleted();
@@ -69,7 +69,7 @@ public class SourceStreamTest {
         when(position.asByteString()).thenReturn(ByteString.copyFromUtf8("irrelevant"));
         when(transformer.apply(sourceRec)).thenReturn(conduitRec);
 
-        new SourceStream(task, position, streamObserver, transformer).start();
+        new DefaultSourceStream(task, position, streamObserver, transformer).startAsync();
 
         var responseCaptor = ArgumentCaptor.forClass(Source.Run.Response.class);
         verify(streamObserver, timeout(1000)).onNext(responseCaptor.capture());
@@ -95,7 +95,7 @@ public class SourceStreamTest {
     private void testConnectorTaskThrows(Throwable surprise) throws InterruptedException {
         when(task.poll()).thenThrow(surprise);
 
-        new SourceStream(task, position, streamObserver, transformer).start();
+        new DefaultSourceStream(task, position, streamObserver, transformer).startAsync();
 
         var captor = ArgumentCaptor.forClass(Throwable.class);
         verify(streamObserver, timeout(100).atLeastOnce()).onError(captor.capture());
@@ -120,7 +120,7 @@ public class SourceStreamTest {
         when(transformer.apply(sr1)).thenReturn(cr1);
         when(transformer.apply(sr2)).thenReturn(cr2);
 
-        new SourceStream(task, position, streamObserver, transformer).start();
+        new DefaultSourceStream(task, position, streamObserver, transformer).startAsync();
         var captor = ArgumentCaptor.forClass(Source.Run.Response.class);
         verify(streamObserver, timeout(500).times(2)).onNext(captor.capture());
 

--- a/src/test/java/io/conduit/SourceStreamTest.java
+++ b/src/test/java/io/conduit/SourceStreamTest.java
@@ -1,12 +1,6 @@
 package io.conduit;
 
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.function.Function;
-
 import com.google.protobuf.ByteString;
-import io.conduit.grpc.Data;
 import io.conduit.grpc.Record;
 import io.conduit.grpc.Source;
 import io.grpc.StatusException;
@@ -20,6 +14,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
 
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -140,8 +139,6 @@ public class SourceStreamTest {
 
     private Record.Builder testConduitRec() {
         return Record.newBuilder()
-                .setPayload(
-                        Data.newBuilder().setRawData(ByteString.copyFromUtf8(UUID.randomUUID().toString())).build()
-                );
+                .setPayload(TestUtils.newRecordPayload(UUID.randomUUID().toString()));
     }
 }

--- a/src/test/java/io/conduit/StructSchemaProviderTest.java
+++ b/src/test/java/io/conduit/StructSchemaProviderTest.java
@@ -1,17 +1,43 @@
 package io.conduit;
 
 import com.google.protobuf.*;
+import io.conduit.grpc.Change;
 import io.conduit.grpc.Data;
 import io.conduit.grpc.Record;
 import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class StructSchemaProviderTest {
+    private StructSchemaProvider underTest;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new StructSchemaProvider("myschema", null);
+    }
+
+    @Test
+    public void testNoPayload() {
+        Record rec = Record.newBuilder()
+                .setKey(Data.newBuilder().setRawData(ByteString.copyFromUtf8("test-key")).build())
+                .build();
+        assertNull(underTest.provide(rec));
+    }
+
+    @Test
+    public void testNoAfter() {
+        Record rec = Record.newBuilder()
+                .setKey(Data.newBuilder().setRawData(ByteString.copyFromUtf8("test-key")).build())
+                .setPayload(Change.newBuilder().build())
+                .build();
+        assertNull(underTest.provide(rec));
+    }
+
     @Test
     public void testNumbers() {
-        StructSchemaProvider underTest = new StructSchemaProvider("myschema", null);
         var struct = Struct.newBuilder()
                 .putFields("byteField", Value.newBuilder().setNumberValue((byte) 5).build())
                 .putFields("shortField", Value.newBuilder().setNumberValue((short) 25).build())
@@ -38,7 +64,6 @@ public class StructSchemaProviderTest {
 
     @Test
     public void testNullField() {
-        StructSchemaProvider underTest = new StructSchemaProvider("myschema", null);
         var struct = Struct.newBuilder()
                 .putFields("nullValueField", Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build())
                 .build();
@@ -54,7 +79,6 @@ public class StructSchemaProviderTest {
 
     @Test
     public void testString() {
-        StructSchemaProvider underTest = new StructSchemaProvider("myschema", null);
         var struct = Struct.newBuilder()
                 .putFields("stringField", Value.newBuilder().setStringValue("test string").build())
                 .build();
@@ -71,7 +95,6 @@ public class StructSchemaProviderTest {
 
     @Test
     public void testStringArray() {
-        StructSchemaProvider underTest = new StructSchemaProvider("myschema", null);
         var struct = Struct.newBuilder()
                 .putFields(
                         "stringArrayField",

--- a/src/test/java/io/conduit/StructSchemaProviderTest.java
+++ b/src/test/java/io/conduit/StructSchemaProviderTest.java
@@ -18,7 +18,8 @@ public class StructSchemaProviderTest {
                 .putFields("intField", Value.newBuilder().setNumberValue(123).build())
                 .putFields("longField", Value.newBuilder().setNumberValue(Long.MAX_VALUE).build())
                 .putFields("floatField", Value.newBuilder().setNumberValue(12.34f).build())
-                .putFields("doubleField", Value.newBuilder().setNumberValue(12.34d).build());
+                .putFields("doubleField", Value.newBuilder().setNumberValue(12.34d).build())
+                .build();
 
         Record record = toRecord(struct);
 
@@ -39,7 +40,8 @@ public class StructSchemaProviderTest {
     public void testNullField() {
         StructSchemaProvider underTest = new StructSchemaProvider("myschema", null);
         var struct = Struct.newBuilder()
-                .putFields("nullValueField", Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build());
+                .putFields("nullValueField", Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build())
+                .build();
 
         Record record = toRecord(struct);
 
@@ -54,7 +56,8 @@ public class StructSchemaProviderTest {
     public void testString() {
         StructSchemaProvider underTest = new StructSchemaProvider("myschema", null);
         var struct = Struct.newBuilder()
-                .putFields("stringField", Value.newBuilder().setStringValue("test string").build());
+                .putFields("stringField", Value.newBuilder().setStringValue("test string").build())
+                .build();
 
         Record record = toRecord(struct);
 
@@ -75,7 +78,7 @@ public class StructSchemaProviderTest {
                         Value.newBuilder()
                                 .setListValue(ListValue.newBuilder().addValues(Value.newBuilder().setStringValue("a").build()))
                                 .build()
-                );
+                ).build();
 
         Record record = toRecord(struct);
 
@@ -88,12 +91,10 @@ public class StructSchemaProviderTest {
         assertEquals(Schema.Type.STRING, result.field("stringArrayField").schema().valueSchema().type());
     }
 
-    private Record toRecord(Struct.Builder struct) {
+    private Record toRecord(Struct struct) {
         return Record.newBuilder()
                 .setKey(Data.newBuilder().setRawData(ByteString.copyFromUtf8("test-key")).build())
-                .setPayload(Data.newBuilder()
-                        .setStructuredData(struct)
-                        .build()
-                ).build();
+                .setPayload(TestUtils.newCreatedRecord(struct))
+                .build();
     }
 }

--- a/src/test/java/io/conduit/TestUtils.java
+++ b/src/test/java/io/conduit/TestUtils.java
@@ -16,6 +16,11 @@
 
 package io.conduit;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Struct;
+import io.conduit.grpc.Change;
+import io.conduit.grpc.Data;
 import io.conduit.grpc.Source;
 
 import java.util.Map;
@@ -24,6 +29,43 @@ public class TestUtils {
     static Source.Configure.Request newConfigRequest(Map<String, String> config) {
         return Source.Configure.Request.newBuilder()
                 .putAllConfig(config)
+                .build();
+    }
+
+    static Change newCreatedRecord(Struct struct) {
+        return Change.newBuilder()
+                .setAfter(Data.newBuilder().setStructuredData(struct).build())
+                .build();
+    }
+
+    static Change newCreatedRecord(byte[] bytes) {
+        Data data = Data.newBuilder()
+                .setRawData(ByteString.copyFrom(bytes))
+                .build();
+        return Change.newBuilder()
+                .setAfter(data)
+                .build();
+    }
+
+    static Change newCreatedRecord(ObjectNode json) {
+        Data data = Data.newBuilder()
+                .setRawData(ByteString.copyFromUtf8(json.toString()))
+                .build();
+        return Change.newBuilder()
+                .setAfter(data)
+                .build();
+    }
+
+    static Change newRecordPayload() {
+        return newRecordPayload("{\"id\":123,\"name\":\"foobar\"}");
+    }
+
+    static Change newRecordPayload(String s) {
+        var data = Data.newBuilder()
+                .setRawData(ByteString.copyFromUtf8(s))
+                .build();
+        return Change.newBuilder()
+                .setAfter(data)
                 .build();
     }
 }

--- a/src/test/java/io/conduit/TransformationsTest.java
+++ b/src/test/java/io/conduit/TransformationsTest.java
@@ -81,9 +81,9 @@ public class TransformationsTest {
         var payload = conduitRec.getPayload().getAfter().getStructuredData();
         assertMatch(testValue, payload);
         // assert timestamp is within last second
-        long createdAt = Long.parseLong(conduitRec.getMetadataOrThrow(OpenCdcMetadata.CREATED_AT));
+        long readAt = Long.parseLong(conduitRec.getMetadataOrThrow(OpenCdcMetadata.READ_AT));
         assertTrue(
-                createdAt / 1_000_000 > System.currentTimeMillis() - 1000
+                readAt / 1_000_000 > System.currentTimeMillis() - 1000
         );
         // verify key
         assertFalse(conduitRec.getKey().hasRawData());
@@ -110,9 +110,9 @@ public class TransformationsTest {
         var payload = conduitRec.getPayload().getAfter().getStructuredData();
         assertMatch(testValue, payload);
         // assert timestamp is within last second
-        long createdAt = Long.parseLong(conduitRec.getMetadataOrThrow(OpenCdcMetadata.CREATED_AT));
+        long readAt = Long.parseLong(conduitRec.getMetadataOrThrow(OpenCdcMetadata.READ_AT));
         assertTrue(
-                createdAt / 1_000_000 > System.currentTimeMillis() - 1000
+                readAt / 1_000_000 > System.currentTimeMillis() - 1000
         );
         // verify key
         assertFalse(conduitRec.getKey().hasRawData());
@@ -226,7 +226,7 @@ public class TransformationsTest {
                 .setKey(Data.newBuilder().setRawData(ByteString.copyFromUtf8(UUID.randomUUID().toString())).build())
                 .setPayload(newStructPayload())
                 .setPosition(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-                .putMetadata(OpenCdcMetadata.CREATED_AT, "123456000000000")
+                .putMetadata(OpenCdcMetadata.READ_AT, "123456000000000")
                 .build();
     }
 
@@ -250,7 +250,7 @@ public class TransformationsTest {
                 .setKey(Data.newBuilder().setRawData(ByteString.copyFromUtf8(UUID.randomUUID().toString())).build())
                 .setPayload(newRawPayloadJson())
                 .setPosition(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-                .putMetadata(OpenCdcMetadata.CREATED_AT, "123456000000000")
+                .putMetadata(OpenCdcMetadata.READ_AT, "123456000000000")
                 .build();
     }
 
@@ -259,7 +259,7 @@ public class TransformationsTest {
                 .setKey(Data.newBuilder().setRawData(ByteString.copyFromUtf8(UUID.randomUUID().toString())).build())
                 .setPayload(newRawPayload())
                 .setPosition(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-                .putMetadata(OpenCdcMetadata.CREATED_AT, "123456000000000")
+                .putMetadata(OpenCdcMetadata.READ_AT, "123456000000000")
                 .build();
     }
 

--- a/src/test/java/io/conduit/TransformationsTest.java
+++ b/src/test/java/io/conduit/TransformationsTest.java
@@ -82,7 +82,7 @@ public class TransformationsTest {
         var payload = conduitRec.getPayload().getAfter().getStructuredData();
         assertMatch(testValue, payload);
         // assert timestamp is within last second
-        int createdAt = Integer.parseInt(conduitRec.getMetadataOrThrow(Opencdc.metadataCreatedAt.getDefaultValue()));
+        long createdAt = Long.parseLong(conduitRec.getMetadataOrThrow(OpenCdc.MetadataCreatedAt));
         assertTrue(
                 createdAt / 1_000_000 > System.currentTimeMillis() - 1000
         );
@@ -111,7 +111,7 @@ public class TransformationsTest {
         var payload = conduitRec.getPayload().getAfter().getStructuredData();
         assertMatch(testValue, payload);
         // assert timestamp is within last second
-        int createdAt = Integer.parseInt(conduitRec.getMetadataOrThrow(Opencdc.metadataCreatedAt.getDefaultValue()));
+        long createdAt = Long.parseLong(conduitRec.getMetadataOrThrow(OpenCdc.MetadataCreatedAt));
         assertTrue(
                 createdAt / 1_000_000 > System.currentTimeMillis() - 1000
         );
@@ -227,7 +227,7 @@ public class TransformationsTest {
                 .setKey(Data.newBuilder().setRawData(ByteString.copyFromUtf8(UUID.randomUUID().toString())).build())
                 .setPayload(newStructPayload())
                 .setPosition(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-                .putMetadata(Opencdc.metadataCreatedAt.getDefaultValue(), "123456000000000")
+                .putMetadata(OpenCdc.MetadataCreatedAt, "123456000000000")
                 .build();
     }
 
@@ -251,7 +251,7 @@ public class TransformationsTest {
                 .setKey(Data.newBuilder().setRawData(ByteString.copyFromUtf8(UUID.randomUUID().toString())).build())
                 .setPayload(newRawPayloadJson())
                 .setPosition(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-                .putMetadata(Opencdc.metadataCreatedAt.getDefaultValue(), "123456000000000")
+                .putMetadata(OpenCdc.MetadataCreatedAt, "123456000000000")
                 .build();
     }
 
@@ -260,7 +260,7 @@ public class TransformationsTest {
                 .setKey(Data.newBuilder().setRawData(ByteString.copyFromUtf8(UUID.randomUUID().toString())).build())
                 .setPayload(newRawPayload())
                 .setPosition(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-                .putMetadata(Opencdc.metadataCreatedAt.getDefaultValue(), "123456000000000")
+                .putMetadata(OpenCdc.MetadataCreatedAt, "123456000000000")
                 .build();
     }
 

--- a/src/test/java/io/conduit/TransformationsTest.java
+++ b/src/test/java/io/conduit/TransformationsTest.java
@@ -152,7 +152,7 @@ public class TransformationsTest {
                 IllegalArgumentException.class,
                 () -> Transformations.toConnectData(rec, null)
         );
-        assertEquals("record has no payload", e.getMessage());
+        assertEquals("record has no payload or has no after data", e.getMessage());
     }
 
     @Test

--- a/src/test/java/io/conduit/TransformationsTest.java
+++ b/src/test/java/io/conduit/TransformationsTest.java
@@ -6,7 +6,6 @@ import com.google.protobuf.Value;
 import com.google.protobuf.util.JsonFormat;
 import io.conduit.grpc.Change;
 import io.conduit.grpc.Data;
-import io.conduit.grpc.Opencdc;
 import io.conduit.grpc.Record;
 import lombok.SneakyThrows;
 import org.apache.kafka.connect.data.Schema;
@@ -82,7 +81,7 @@ public class TransformationsTest {
         var payload = conduitRec.getPayload().getAfter().getStructuredData();
         assertMatch(testValue, payload);
         // assert timestamp is within last second
-        long createdAt = Long.parseLong(conduitRec.getMetadataOrThrow(OpenCdc.MetadataCreatedAt));
+        long createdAt = Long.parseLong(conduitRec.getMetadataOrThrow(OpenCdcMetadata.CREATED_AT));
         assertTrue(
                 createdAt / 1_000_000 > System.currentTimeMillis() - 1000
         );
@@ -111,7 +110,7 @@ public class TransformationsTest {
         var payload = conduitRec.getPayload().getAfter().getStructuredData();
         assertMatch(testValue, payload);
         // assert timestamp is within last second
-        long createdAt = Long.parseLong(conduitRec.getMetadataOrThrow(OpenCdc.MetadataCreatedAt));
+        long createdAt = Long.parseLong(conduitRec.getMetadataOrThrow(OpenCdcMetadata.CREATED_AT));
         assertTrue(
                 createdAt / 1_000_000 > System.currentTimeMillis() - 1000
         );
@@ -227,7 +226,7 @@ public class TransformationsTest {
                 .setKey(Data.newBuilder().setRawData(ByteString.copyFromUtf8(UUID.randomUUID().toString())).build())
                 .setPayload(newStructPayload())
                 .setPosition(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-                .putMetadata(OpenCdc.MetadataCreatedAt, "123456000000000")
+                .putMetadata(OpenCdcMetadata.CREATED_AT, "123456000000000")
                 .build();
     }
 
@@ -251,7 +250,7 @@ public class TransformationsTest {
                 .setKey(Data.newBuilder().setRawData(ByteString.copyFromUtf8(UUID.randomUUID().toString())).build())
                 .setPayload(newRawPayloadJson())
                 .setPosition(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-                .putMetadata(OpenCdc.MetadataCreatedAt, "123456000000000")
+                .putMetadata(OpenCdcMetadata.CREATED_AT, "123456000000000")
                 .build();
     }
 
@@ -260,7 +259,7 @@ public class TransformationsTest {
                 .setKey(Data.newBuilder().setRawData(ByteString.copyFromUtf8(UUID.randomUUID().toString())).build())
                 .setPayload(newRawPayload())
                 .setPosition(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-                .putMetadata(OpenCdc.MetadataCreatedAt, "123456000000000")
+                .putMetadata(OpenCdcMetadata.CREATED_AT, "123456000000000")
                 .build();
     }
 


### PR DESCRIPTION
Fixes part 1 of #114.

In this PR, we keep the same level of functionality as before, but we use the updated API, with the OpenCDC changes. Since Kafka Connect connectors generally do not support CDC, this PR interprets all incoming records as created records. In #124 Debezium CDC records are transformed into OpenCDC records. 

