### PR TITLE
List available connectors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
+            <version>4.8.162</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.30</version>

--- a/src/main/java/io/conduit/SpecifierService.java
+++ b/src/main/java/io/conduit/SpecifierService.java
@@ -16,86 +16,129 @@
 
 package io.conduit;
 
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 import io.conduit.grpc.Specifier;
+import io.conduit.grpc.Specifier.Parameter.Validation;
 import io.conduit.grpc.Specifier.Specify.Request;
 import io.conduit.grpc.Specifier.Specify.Response;
 import io.conduit.grpc.SpecifierPluginGrpc;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ClassInfoList;
+import io.github.classgraph.ScanResult;
 import io.grpc.stub.StreamObserver;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A gRPC service exposing this connector's specification.
  */
 public class SpecifierService extends SpecifierPluginGrpc.SpecifierPluginImplBase {
-    private static final Map<String, Specifier.Parameter> SOURCE_PARAMS = Map.of(
-            "wrapper.connector.class",
-            Specifier.Parameter.newBuilder()
-                    .setDescription(
-                            "The class of the requested connector. "
-                            + "It needs to be found on the classpath, i.e. in a JAR in the `libs` directory. ")
-                    .setDefault("none")
-                    .setRequired(true)
-                    .build()
-    );
+    public static final Logger logger = LoggerFactory.getLogger(SpecifierService.class);
 
-    private static final Map<String, Specifier.Parameter> DESTINATION_PARAMS = Map.of(
-            "wrapper.connector.class",
-            Specifier.Parameter.newBuilder()
-                    .setDescription(
-                            "The class of the requested connector. "
-                            + "It needs to be found on the classpath, i.e. in a JAR in the `libs` directory. ")
-                    .setDefault("none")
-                    .setRequired(true)
-                    .build(),
-
-            "wrapper.schema",
-            Specifier.Parameter.newBuilder()
-                    .setDescription("The schema of the records which will be written to a destination connector.")
-                    .setDefault("none")
-                    .setRequired(false)
-                    .build(),
-
-            "wrapper.schema.autogenerate.enabled",
-            Specifier.Parameter.newBuilder()
-                    .setDescription(
-                            "Automatically generate schemas (destination connector). "
-                            + "Cannot be `true` if a schema is set.")
-                    .setDefault("none")
-                    .setRequired(false)
-                    .build(),
-
-            "wrapper.schema.autogenerate.name",
-            Specifier.Parameter.newBuilder()
-                    .setDescription("Name of automatically generated schema. "
-                            + "Required if schema auto-generation is turned on.")
-                    .setDefault("none")
-                    .setRequired(false)
-                    .build(),
-
-            "wrapper.schema.autogenerate.overrides",
-            Specifier.Parameter.newBuilder()
-                    .setDescription("A (partial) schema which overrides types in the auto-generated schema.")
-                    .setDefault("none")
-                    .setRequired(false)
-                    .build()
-    );
+    private static final Validation requiredValidation = Validation.newBuilder()
+        .setType(Validation.Type.TYPE_REQUIRED)
+        .build();
 
     @Override
     public void specify(Request request, StreamObserver<Response> responseObserver) {
         responseObserver.onNext(
-                Response.newBuilder()
-                        .setName("conduit-kafka-connect-wrapper")
-                        .setSummary("Kafka Connect wrapper")
-                        .setDescription(
-                                "Conduit's Kafka Connect wrapper makes it possible "
-                                + "to use existing Kafka Connect connectors with Conduit.")
-                        .setVersion("v0.3.0")
-                        .setAuthor("Meroxa, Inc.")
-                        .putAllSourceParams(SOURCE_PARAMS)
-                        .putAllDestinationParams(DESTINATION_PARAMS)
-                        .build()
+            Response.newBuilder()
+                .setName("conduit-kafka-connect-wrapper")
+                .setSummary("Kafka Connect wrapper")
+                .setDescription(
+                    "Conduit's Kafka Connect wrapper makes it possible "
+                        + "to use existing Kafka Connect connectors with Conduit.")
+                .setVersion("v0.3.0")
+                .setAuthor("Meroxa, Inc.")
+                .putAllSourceParams(buildSourceParams())
+                .putAllDestinationParams(buildDestinationParams())
+                .build()
         );
         responseObserver.onCompleted();
+    }
+
+    private Map<String, Specifier.Parameter> buildDestinationParams() {
+        return Map.of(
+            "wrapper.connector.class",
+            Specifier.Parameter.newBuilder()
+                .setDescription(
+                    "The class of the requested connector. "
+                        + "It needs to be found on the classpath, i.e. in a JAR in the `libs` directory. ")
+                .setDefault("none")
+                .addValidations(requiredValidation)
+                .build(),
+
+            "wrapper.schema",
+            Specifier.Parameter.newBuilder()
+                .setDescription("The schema of the records which will be written to a destination connector.")
+                .setDefault("none")
+                .build(),
+
+            "wrapper.schema.autogenerate.enabled",
+            Specifier.Parameter.newBuilder()
+                .setDescription(
+                    "Automatically generate schemas (destination connector). "
+                        + "Cannot be `true` if a schema is set.")
+                .setDefault("none")
+                .build(),
+
+            "wrapper.schema.autogenerate.name",
+            Specifier.Parameter.newBuilder()
+                .setDescription("Name of automatically generated schema. "
+                    + "Required if schema auto-generation is turned on.")
+                .setDefault("none")
+                .build(),
+
+            "wrapper.schema.autogenerate.overrides",
+            Specifier.Parameter.newBuilder()
+                .setDescription("A (partial) schema which overrides types in the auto-generated schema.")
+                .setDefault("none")
+                .build()
+        );
+    }
+
+    private Map<String, Specifier.Parameter> buildSourceParams() {
+        var availableConnectors = Validation.newBuilder()
+            .setType(Validation.Type.TYPE_INCLUSION)
+            .setValue(loadAvailableConnectors())
+            .build();
+
+        return Map.of(
+            "wrapper.connector.class",
+            Specifier.Parameter.newBuilder()
+                .setDescription(
+                    "The class of the requested connector. "
+                        + "It needs to be found on the classpath, i.e. in a JAR in the `libs` directory. ")
+                .setDefault("none")
+                .addValidations(requiredValidation)
+                .addValidations(availableConnectors)
+                .build()
+        );
+    }
+
+    private String loadAvailableConnectors() {
+        List<String> connectors = new LinkedList<>();
+
+        ClassGraph cg = new ClassGraph()
+            .verbose(false)
+            .enableClassInfo()
+            .acceptLibOrExtJars();
+
+        try (ScanResult scanResult = cg.scan()) {
+            ClassInfoList controlClasses = scanResult.getSubclasses(SourceConnector.class.getName());
+            for (ClassInfo cc : controlClasses) {
+                if (!cc.isAbstract()) {
+                    connectors.add(cc.getName());
+                }
+            }
+        }
+
+        logger.info("Found connectors {}", connectors);
+        return String.join(",", connectors);
     }
 }

--- a/src/main/proto/connector.proto
+++ b/src/main/proto/connector.proto
@@ -8,14 +8,18 @@ option java_package = "io.conduit.grpc";
 import "google/protobuf/descriptor.proto";
 import "opencdc.proto";
 
-option (metadata_conduit_plugin_name) = "conduit.plugin.name";
-option (metadata_conduit_plugin_version) = "conduit.plugin.version";
+option (metadata_conduit_destination_plugin_name) = "conduit.destination.plugin.name";
+option (metadata_conduit_destination_plugin_version) = "conduit.destination.plugin.version";
+option (metadata_conduit_source_plugin_name) = "conduit.source.plugin.name";
+option (metadata_conduit_source_plugin_version) = "conduit.source.plugin.version";
 
 // We are (ab)using custom file options to define constants.
 // See https://github.com/protocolbuffers/protobuf/issues/3520#issuecomment-323613839
 extend google.protobuf.FileOptions {
-  string metadata_conduit_plugin_name = 20000;
-  string metadata_conduit_plugin_version = 20001;
+  string metadata_conduit_source_plugin_name = 20000;
+  string metadata_conduit_source_plugin_version = 20001;
+  string metadata_conduit_destination_plugin_name = 20002;
+  string metadata_conduit_destination_plugin_version = 20003;
 }
 
 // SourcePlugin is responsible for fetching records from 3rd party resources and
@@ -53,6 +57,27 @@ service SourcePlugin {
   // other function. After Teardown returns, the plugin should be ready for a
   // graceful shutdown.
   rpc Teardown(Source.Teardown.Request) returns (Source.Teardown.Response);
+
+  // -- Lifecycle events -------------------------------------------------------
+
+  // LifecycleOnCreated is called after Configure and before Start when the
+  // connector is run for the first time. This call will be skipped if a
+  // connector was already started before. This method can be used to do some
+  // initialization that needs to happen only once in the lifetime of a
+  // connector (e.g. create a replication slot). Anything that the connector
+  // creates in this method is considered to be owned by this connector and
+  // should be cleaned up in LifecycleOnDeleted.
+  rpc LifecycleOnCreated(Source.Lifecycle.OnCreated.Request) returns (Source.Lifecycle.OnCreated.Response);
+  // LifecycleOnUpdated is called after Configure and before Start when the
+  // connector configuration has changed since the last run. This call will be
+  // skipped if the connector configuration did not change. It can be used to
+  // update anything that was initialized in LifecycleOnCreated, in case the
+  // configuration change affects it.
+  rpc LifecycleOnUpdated(Source.Lifecycle.OnUpdated.Request) returns (Source.Lifecycle.OnUpdated.Response);
+  // LifecycleOnDeleted is called when the connector was deleted. It will be the
+  // only method that is called in that case. This method can be used to clean
+  // up anything that was initialized in LifecycleOnCreated.
+  rpc LifecycleOnDeleted(Source.Lifecycle.OnDeleted.Request) returns (Source.Lifecycle.OnDeleted.Response);
 }
 
 // DestinationPlugin is responsible for writing records to 3rd party resources.
@@ -82,6 +107,27 @@ service DestinationPlugin {
   // other function. After Teardown returns, the plugin should be ready for a
   // graceful shutdown.
   rpc Teardown(Destination.Teardown.Request) returns (Destination.Teardown.Response);
+
+  // -- Lifecycle events -------------------------------------------------------
+
+  // LifecycleOnCreated is called after Configure and before Start when the
+  // connector is run for the first time. This call will be skipped if a
+  // connector was already started before. This method can be used to do some
+  // initialization that needs to happen only once in the lifetime of a
+  // connector (e.g. create a bucket). Anything that the connector creates in
+  // this method is considered to be owned by this connector and should be
+  // cleaned up in LifecycleOnDeleted.
+  rpc LifecycleOnCreated(Destination.Lifecycle.OnCreated.Request) returns (Destination.Lifecycle.OnCreated.Response);
+  // LifecycleOnUpdated is called after Configure and before Start when the
+  // connector configuration has changed since the last run. This call will be
+  // skipped if the connector configuration did not change. It can be used to
+  // update anything that was initialized in LifecycleOnCreated, in case the
+  // configuration change affects it.
+  rpc LifecycleOnUpdated(Destination.Lifecycle.OnUpdated.Request) returns (Destination.Lifecycle.OnUpdated.Response);
+  // LifecycleOnDeleted is called when the connector was deleted. It will be the
+  // only method that is called in that case. This method can be used to clean
+  // up anything that was initialized in LifecycleOnCreated.
+  rpc LifecycleOnDeleted(Destination.Lifecycle.OnDeleted.Request) returns (Destination.Lifecycle.OnDeleted.Response);
 }
 
 // SpecifierPlugin is responsible for returning the plugin specification.
@@ -138,6 +184,38 @@ message Source {
     message Request {}
     message Response {}
   }
+
+  message Lifecycle {
+    message OnCreated {
+      message Request {
+        // This is the connector configuration that was also passed to
+        // Configure, therefore it's already validated.
+        map<string, string> config = 1;
+      }
+      message Response {}
+    }
+    message OnUpdated {
+      message Request {
+        // This is the old connector configuration that was used the last time
+        // the connector was running. It was valid at that time, since it passed
+        // through the Configure function.
+        map<string, string> config_before = 1;
+        // This is the new connector configuration that was also passed to
+        // Configure, therefore it's already validated.
+        map<string, string> config_after = 2;
+      }
+      message Response {}
+    }
+    message OnDeleted {
+      message Request {
+        // This is the old connector configuration that was used the last time
+        // the connector was running. It was valid at that time, since it passed
+        // through the Configure function.
+        map<string, string> config = 1;
+      }
+      message Response {}
+    }
+  }
 }
 
 message Destination {
@@ -184,6 +262,38 @@ message Destination {
     message Request {}
     message Response {}
   }
+
+  message Lifecycle {
+    message OnCreated {
+      message Request {
+        // This is the connector configuration that was also passed to
+        // Configure, therefore it's already validated.
+        map<string, string> config = 1;
+      }
+      message Response {}
+    }
+    message OnUpdated {
+      message Request {
+        // This is the old connector configuration that was used the last time
+        // the connector was running. It was valid at that time, since it passed
+        // through the Configure function.
+        map<string, string> config_before = 1;
+        // This is the new connector configuration that was also passed to
+        // Configure, therefore it's already validated.
+        map<string, string> config_after = 2;
+      }
+      message Response {}
+    }
+    message OnDeleted {
+      message Request {
+        // This is the old connector configuration that was used the last time
+        // the connector was running. It was valid at that time, since it passed
+        // through the Configure function.
+        map<string, string> config = 1;
+      }
+      message Response {}
+    }
+  }
 }
 
 message Specifier {
@@ -215,13 +325,59 @@ message Specifier {
 
   // Parameter describes a single config parameter.
   message Parameter {
+    // Validation to be made on the parameter.
+    message Validation {
+      enum Type {
+        TYPE_UNSPECIFIED = 0;
+        // Parameter must be present.
+        TYPE_REQUIRED = 1;
+        // Parameter must be greater than {value}.
+        TYPE_GREATER_THAN = 2;
+        // Parameter must be less than {value}.
+        TYPE_LESS_THAN = 3;
+        // Parameter must be included in the comma separated list {value}.
+        TYPE_INCLUSION = 4;
+        // Parameter must not be included in the comma separated list {value}.
+        TYPE_EXCLUSION = 5;
+        // Parameter must match the regex {value}.
+        TYPE_REGEX = 6;
+      }
+
+      Type type = 1;
+      // The value to be compared with the parameter,
+      // or a comma separated list in case of Validation.TYPE_INCLUSION or Validation.TYPE_EXCLUSION.
+      string value = 2;
+    }
+
+    // Type shows the parameter type.
+    enum Type {
+      TYPE_UNSPECIFIED = 0;
+      // Parameter is a string.
+      TYPE_STRING = 1;
+      // Parameter is an integer.
+      TYPE_INT = 2;
+      // Parameter is a float.
+      TYPE_FLOAT = 3;
+      // Parameter is a boolean.
+      TYPE_BOOL = 4;
+      // Parameter is a file.
+      TYPE_FILE = 5;
+      // Parameter is a duration.
+      TYPE_DURATION = 6;
+    }
+
     // Default is the default value of the parameter. If there is no default
     // value use an empty string.
     string default = 1;
     // Required defines whether the parameter has to be provided when
     // configuring the plugin.
-    bool required = 2;
+    // Deprecated: add a validation of type TYPE_REQUIRED to the validations list.
+    bool required = 2 [deprecated = true];
     // Description explains what the parameter does and how to configure it.
     string description = 3;
+    // Type defines the parameter data type.
+    Type type = 4;
+    // Validations are validations to be made on the parameter.
+    repeated Validation validations = 5;
   }
 }

--- a/src/main/proto/opencdc.proto
+++ b/src/main/proto/opencdc.proto
@@ -8,22 +8,21 @@ option java_package = "io.conduit.grpc";
 import "google/protobuf/descriptor.proto";
 import "google/protobuf/struct.proto";
 
-// OpenCDC version is a constant that should be used as the value in the
-// metadata field opencdc.version. It ensures the OpenCDC format version can be
-// easily identified in case the record gets marshaled into a different untyped
-// format (e.g. JSON).
-option (opencdc_version) = "v1";
-
-// Version contains the version of the OpenCDC format (e.g. "v1"). This field
-// exists to ensure the OpenCDC format version can be easily identified in case
-// the record gets marshaled into a different untyped format (e.g. JSON).
-option (metadata_version) = "opencdc.version";
 // CreatedAt can contain the time when the record was created in the 3rd party
 // system. The expected format is a unix timestamp in nanoseconds.
 option (metadata_created_at) = "opencdc.createdAt";
 // ReadAt can contain the time when the record was read from the 3rd party
 // system. The expected format is a unix timestamp in nanoseconds.
 option (metadata_read_at) = "opencdc.readAt";
+// Version contains the version of the OpenCDC format (e.g. "v1"). This field
+// exists to ensure the OpenCDC format version can be easily identified in case
+// the record gets marshaled into a different untyped format (e.g. JSON).
+option (metadata_version) = "opencdc.version";
+// OpenCDC version is a constant that should be used as the value in the
+// metadata field opencdc.version. It ensures the OpenCDC format version can be
+// easily identified in case the record gets marshaled into a different untyped
+// format (e.g. JSON).
+option (opencdc_version) = "v1";
 
 // We are (ab)using custom file options to define constants.
 // See https://github.com/protocolbuffers/protobuf/issues/3520#issuecomment-323613839

--- a/src/test/java/io/conduit/SpecifierServiceTest.java
+++ b/src/test/java/io/conduit/SpecifierServiceTest.java
@@ -33,8 +33,9 @@ import static org.mockito.Mockito.verify;
 
 class SpecifierServiceTest {
     @Test
-    public void testSpecify() {
+    void testSpecify() {
         var observer = mock(StreamObserver.class);
+
         new SpecifierService().specify(
             Request.newBuilder().build(),
             observer

--- a/src/test/java/io/conduit/SpecifierServiceTest.java
+++ b/src/test/java/io/conduit/SpecifierServiceTest.java
@@ -16,12 +16,18 @@
 
 package io.conduit;
 
+import java.util.Arrays;
+import java.util.Map;
+
+import io.conduit.grpc.Specifier;
+import io.conduit.grpc.Specifier.Parameter.Validation;
 import io.conduit.grpc.Specifier.Specify.Request;
 import io.conduit.grpc.Specifier.Specify.Response;
 import io.grpc.stub.StreamObserver;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -62,8 +68,42 @@ class SpecifierServiceTest {
 
         assertNotNull(response.getSourceParamsMap());
         assertFalse(response.getSourceParamsMap().isEmpty());
+        verifyWrapperClassValidations(
+            new String[]{
+                "io.aiven.connect.jdbc.JdbcSourceConnector",
+                "io.debezium.connector.postgresql.PostgresConnector"
+            },
+            response.getSourceParamsMap()
+        );
 
         assertNotNull(response.getDestinationParamsMap());
         assertFalse(response.getDestinationParamsMap().isEmpty());
+        verifyWrapperClassValidations(
+            new String[]{
+                "com.snowflake.kafka.connector.SnowflakeSinkConnector",
+                "io.aiven.connect.jdbc.JdbcSinkConnector"
+            },
+            response.getDestinationParamsMap()
+        );
+    }
+
+    private void verifyWrapperClassValidations(String[] expected, Map<String, Specifier.Parameter> params) {
+        var validations = params.get("wrapper.connector.class").getValidationsList();
+        assertNotNull(validations);
+        assertEquals(2, validations.size());
+        var required = validations.stream()
+            .filter(v -> v.getType() == Validation.Type.TYPE_REQUIRED)
+            .findFirst();
+        assertTrue(required.isPresent());
+
+
+        var values = validations.stream()
+            .filter(v -> v.getType() == Validation.Type.TYPE_INCLUSION)
+            .findFirst();
+        assertTrue(values.isPresent());
+        Arrays.sort(expected);
+        var actual = values.get().getValue().split(",");
+        Arrays.sort(actual);
+        assertArrayEquals(expected, actual);
     }
 }


### PR DESCRIPTION
This PR:
* Updates the proto files for  the Conduit Connector API
* Lists available Kafka Connect source connectors as possible values for `wrapper.connector.class` in a source connector
* Lists available Kafka Connect sink connectors as possible values for `wrapper.connector.class` in a destination connector

**Example**:
Let's assume the wrapper is built and the following JARs are present in the libs directory:
```shell
dist/libs/
├── checker-qual-3.5.0.jar
├── conduit-kafka-connect-wrapper-0.3.0.jar
├── debezium-api-2.3.4.Final.jar
├── debezium-connector-postgres-2.3.4.Final.jar
├── debezium-core-2.3.4.Final.jar
├── jackson-annotations-2.13.4.jar
├── jackson-core-2.13.4.jar
├── jackson-databind-2.13.4.2.jar
├── jackson-datatype-jsr310-2.13.4.jar
├── jdbc-connector-for-apache-kafka-6.7.0.jar
├── postgresql-42.5.1.jar
├── protobuf-java-3.19.6.jar
└── slf4j-api-1.7.36.jar
```

Calling the specify endpoint will return this:
```shell
grpcurl -plaintext -proto src/main/proto/connector.proto -import-path src/main/proto/ localhost:$PORT connector.v1.SpecifierPlugin.Specify
{
  "name": "conduit-kafka-connect-wrapper",
  "summary": "Kafka Connect wrapper",
  "description": "Conduit's Kafka Connect wrapper makes it possible to use existing Kafka Connect connectors with Conduit.",
  "version": "v0.3.0",
  "author": "Meroxa, Inc.",
  "destinationParams": {
    "wrapper.connector.class": {
      "default": "none",
      "description": "The class of the requested connector. It needs to be found on the classpath, i.e. in a JAR in the `libs` directory. ",
      "validations": [
        {
          "type": "TYPE_REQUIRED"
        },
        {
          "type": "TYPE_INCLUSION",
          "value": "io.aiven.connect.jdbc.JdbcSinkConnector"
        }
      ]
    },
    "wrapper.schema": {
      "default": "none",
      "description": "The schema of the records which will be written to a destination connector."
    },
    "wrapper.schema.autogenerate.enabled": {
      "default": "none",
      "description": "Automatically generate schemas (destination connector). Cannot be `true` if a schema is set."
    },
    "wrapper.schema.autogenerate.name": {
      "default": "none",
      "description": "Name of automatically generated schema. Required if schema auto-generation is turned on."
    },
    "wrapper.schema.autogenerate.overrides": {
      "default": "none",
      "description": "A (partial) schema which overrides types in the auto-generated schema."
    }
  },
  "sourceParams": {
    "wrapper.connector.class": {
      "default": "none",
      "description": "The class of the requested connector. It needs to be found on the classpath, i.e. in a JAR in the `libs` directory. ",
      "validations": [
        {
          "type": "TYPE_REQUIRED"
        },
        {
          "type": "TYPE_INCLUSION",
          "value": "io.aiven.connect.jdbc.JdbcSourceConnector,io.debezium.connector.postgresql.PostgresConnector"
        }
      ]
    }
  }
}
```