### PR TITLE
allow empty after for debezium deletes

### DIFF
--- a/src/main/java/io/conduit/DebeziumToOpenCDC.java
+++ b/src/main/java/io/conduit/DebeziumToOpenCDC.java
@@ -16,6 +16,7 @@
 
 package io.conduit;
 
+import java.io.InvalidObjectException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -89,10 +90,20 @@ public class DebeziumToOpenCDC extends SourceRecordConverter implements Function
         // which are present in the record,
         // i.e. this is not the schema of the whole source table.
         ObjectNode valSchema = Utils.mapper.createObjectNode();
-        Struct after = ((Struct) rec.value()).getStruct("after");
-        for (Field f : after.schema().fields()) {
+        Struct struct = ((Struct) rec.value()).getStruct("after");
+        // fall back to the before field, if after is empty
+        if (struct == null) {
+            struct = ((Struct) rec.value()).getStruct("before");
+        }
+        // if before and after are empty, throw an exception
+        if (struct == null) {
+            throw new InvalidObjectException("after and before fields are empty for record key: " + rec.key());
+        }
+
+        for (Field f : struct.schema().fields()) {
             valSchema.put(f.name(), f.schema().type().toString());
         }
+
         meta.put("kafkaconnect.value.schema", Utils.mapper.writeValueAsString(valSchema));
 
         ObjectNode keySchema = Utils.mapper.createObjectNode();

--- a/src/main/java/io/conduit/DebeziumToOpenCDC.java
+++ b/src/main/java/io/conduit/DebeziumToOpenCDC.java
@@ -16,7 +16,6 @@
 
 package io.conduit;
 
-import java.io.InvalidObjectException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -97,7 +96,7 @@ public class DebeziumToOpenCDC extends SourceRecordConverter implements Function
         }
         // if before and after are empty, throw an exception
         if (struct == null) {
-            throw new InvalidObjectException("after and before fields are empty for record key: " + rec.key());
+            throw new IllegalArgumentException("after and before fields are empty for record key: " + rec.key());
         }
 
         for (Field f : struct.schema().fields()) {

--- a/src/test/resources/debezium-record-deleted.json
+++ b/src/test/resources/debezium-record-deleted.json
@@ -1,0 +1,203 @@
+{
+  "schema": {
+    "type": "struct",
+    "fields": [
+      {
+        "type": "struct",
+        "fields": [
+          {
+            "type": "int32",
+            "optional": false,
+            "default": 0,
+            "field": "id"
+          },
+          {
+            "type": "string",
+            "optional": true,
+            "field": "name"
+          },
+          {
+            "type": "boolean",
+            "optional": true,
+            "field": "full_time"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "name": "io.debezium.time.ZonedTimestamp",
+            "version": 1,
+            "field": "updated_at"
+          }
+        ],
+        "optional": true,
+        "name": "test_server.public.employees.Value",
+        "field": "before"
+      },
+      {
+        "type": "struct",
+        "fields": [
+          {
+            "type": "int32",
+            "optional": false,
+            "default": 0,
+            "field": "id"
+          },
+          {
+            "type": "string",
+            "optional": true,
+            "field": "name"
+          },
+          {
+            "type": "boolean",
+            "optional": true,
+            "field": "full_time"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "name": "io.debezium.time.ZonedTimestamp",
+            "version": 1,
+            "field": "updated_at"
+          }
+        ],
+        "optional": true,
+        "name": "test_server.public.employees.Value",
+        "field": "after"
+      },
+      {
+        "type": "struct",
+        "fields": [
+          {
+            "type": "string",
+            "optional": false,
+            "field": "version"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "connector"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "name"
+          },
+          {
+            "type": "int64",
+            "optional": false,
+            "field": "ts_ms"
+          },
+          {
+            "type": "string",
+            "optional": true,
+            "name": "io.debezium.data.Enum",
+            "version": 1,
+            "parameters": {
+              "allowed": "true,last,false,incremental"
+            },
+            "default": "false",
+            "field": "snapshot"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "db"
+          },
+          {
+            "type": "string",
+            "optional": true,
+            "field": "sequence"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "schema"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "table"
+          },
+          {
+            "type": "int64",
+            "optional": true,
+            "field": "txId"
+          },
+          {
+            "type": "int64",
+            "optional": true,
+            "field": "lsn"
+          },
+          {
+            "type": "int64",
+            "optional": true,
+            "field": "xmin"
+          }
+        ],
+        "optional": false,
+        "name": "io.debezium.connector.postgresql.Source",
+        "field": "source"
+      },
+      {
+        "type": "string",
+        "optional": false,
+        "field": "op"
+      },
+      {
+        "type": "int64",
+        "optional": true,
+        "field": "ts_ms"
+      },
+      {
+        "type": "struct",
+        "fields": [
+          {
+            "type": "string",
+            "optional": false,
+            "field": "id"
+          },
+          {
+            "type": "int64",
+            "optional": false,
+            "field": "total_order"
+          },
+          {
+            "type": "int64",
+            "optional": false,
+            "field": "data_collection_order"
+          }
+        ],
+        "optional": true,
+        "field": "transaction"
+      }
+    ],
+    "optional": false,
+    "name": "test_server.public.employees.Envelope"
+  },
+  "payload": {
+    "before": {
+      "id": 1,
+      "name": "foobar",
+      "full_time": false,
+      "updated_at": "2022-09-19T11:53:48.96726Z"
+    },
+    "after": null,
+    "source": {
+      "version": "1.9.5.Final",
+      "connector": "postgresql",
+      "name": "test-server",
+      "ts_ms": 1663588429999,
+      "snapshot": "false",
+      "db": "meroxadb",
+      "sequence": "[null,\"28782096\"]",
+      "schema": "public",
+      "table": "employees",
+      "txId": 889,
+      "lsn": 28782096,
+      "xmin": null
+    },
+    "op": "d",
+    "ts_ms": 1663588429999,
+    "transaction": null
+  }
+}

--- a/src/test/resources/debezium-record-invalid.json
+++ b/src/test/resources/debezium-record-invalid.json
@@ -1,0 +1,198 @@
+{
+  "schema": {
+    "type": "struct",
+    "fields": [
+      {
+        "type": "struct",
+        "fields": [
+          {
+            "type": "int32",
+            "optional": false,
+            "default": 0,
+            "field": "id"
+          },
+          {
+            "type": "string",
+            "optional": true,
+            "field": "name"
+          },
+          {
+            "type": "boolean",
+            "optional": true,
+            "field": "full_time"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "name": "io.debezium.time.ZonedTimestamp",
+            "version": 1,
+            "field": "updated_at"
+          }
+        ],
+        "optional": true,
+        "name": "test_server.public.employees.Value",
+        "field": "before"
+      },
+      {
+        "type": "struct",
+        "fields": [
+          {
+            "type": "int32",
+            "optional": false,
+            "default": 0,
+            "field": "id"
+          },
+          {
+            "type": "string",
+            "optional": true,
+            "field": "name"
+          },
+          {
+            "type": "boolean",
+            "optional": true,
+            "field": "full_time"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "name": "io.debezium.time.ZonedTimestamp",
+            "version": 1,
+            "field": "updated_at"
+          }
+        ],
+        "optional": true,
+        "name": "test_server.public.employees.Value",
+        "field": "after"
+      },
+      {
+        "type": "struct",
+        "fields": [
+          {
+            "type": "string",
+            "optional": false,
+            "field": "version"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "connector"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "name"
+          },
+          {
+            "type": "int64",
+            "optional": false,
+            "field": "ts_ms"
+          },
+          {
+            "type": "string",
+            "optional": true,
+            "name": "io.debezium.data.Enum",
+            "version": 1,
+            "parameters": {
+              "allowed": "true,last,false,incremental"
+            },
+            "default": "false",
+            "field": "snapshot"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "db"
+          },
+          {
+            "type": "string",
+            "optional": true,
+            "field": "sequence"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "schema"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "table"
+          },
+          {
+            "type": "int64",
+            "optional": true,
+            "field": "txId"
+          },
+          {
+            "type": "int64",
+            "optional": true,
+            "field": "lsn"
+          },
+          {
+            "type": "int64",
+            "optional": true,
+            "field": "xmin"
+          }
+        ],
+        "optional": false,
+        "name": "io.debezium.connector.postgresql.Source",
+        "field": "source"
+      },
+      {
+        "type": "string",
+        "optional": false,
+        "field": "op"
+      },
+      {
+        "type": "int64",
+        "optional": true,
+        "field": "ts_ms"
+      },
+      {
+        "type": "struct",
+        "fields": [
+          {
+            "type": "string",
+            "optional": false,
+            "field": "id"
+          },
+          {
+            "type": "int64",
+            "optional": false,
+            "field": "total_order"
+          },
+          {
+            "type": "int64",
+            "optional": false,
+            "field": "data_collection_order"
+          }
+        ],
+        "optional": true,
+        "field": "transaction"
+      }
+    ],
+    "optional": false,
+    "name": "test_server.public.employees.Envelope"
+  },
+  "payload": {
+    "before": null,
+    "after": null,
+    "source": {
+      "version": "1.9.5.Final",
+      "connector": "postgresql",
+      "name": "test-server",
+      "ts_ms": 1663588428968,
+      "snapshot": "false",
+      "db": "meroxadb",
+      "sequence": "[null,\"28782096\"]",
+      "schema": "public",
+      "table": "employees",
+      "txId": 889,
+      "lsn": 28782096,
+      "xmin": null
+    },
+    "op": "u",
+    "ts_ms": 1663588429947,
+    "transaction": null
+  }
+}


### PR DESCRIPTION
When debezium postgres produces delete records, the `after` field is `null`, which results in the following error:

> ```bash 2024-02-14T12:11:18+00:00 DBG received error on error channel error="error reading from source: couldn't read record: Cannot invoke \"org.apache.kafka.connect.data.Struct.schema()\" because \"after\" is null" component=SourceNode node_id=kafka-to-sf:dbz.in pipeline_id=kafka-to-sf stack=[{"file":"/Users/samir/go/src/conduit/pkg/pipeline/stream/source.go","func":"github.com/conduitio/conduit/pkg/pipeline/stream.(*SourceNode).Run.func1","line":87},{"file":"/Users/samir/go/src/conduit/pkg/plugin/standalone/v1/client.go","func":"github.com/conduitio/conduit/pkg/plugin/standalone/v1.unwrapGRPCError","line":165}] ```

This PR aims to fix that error by allowing `null` in the `after` field.